### PR TITLE
Fix unwinding trivial frames without debug info

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -471,13 +471,12 @@ fn backtrace(
             .unwrap_or("<unknown>");
         println!("{:>4}: {:#010x} - {}", frame, pc, name);
 
-        let fde = debug_frame.fde_for_address(bases, pc.into(), DebugFrame::cie_from_offset).with_context(|| {
+        let uwt_row = debug_frame.unwind_info_for_address(bases, ctx, pc.into(), DebugFrame::cie_from_offset).with_context(|| {
             "debug information is missing. Likely fixes:
 1. compile the Rust code with `debug = 1` or higher. This is configured in the `profile.*` section of Cargo.toml
 2. use a recent version of the `cortex-m` crates (e.g. cortex-m 0.6.3 or newer). Check versions in Cargo.lock
 3. if linking to C code, compile the C code with the `-g` flag"
         })?;
-        let uwt_row = fde.unwind_info_for_address(&debug_frame, bases, ctx, pc.into())?;
 
         let cfa_changed = registers.update_cfa(uwt_row.cfa())?;
 


### PR DESCRIPTION
Fixes #9 (hopefully)

This needs more testing, and the FIXME should probably be addressed as well.

Previously we couldn't produce this backtrace for the `exception` defmt example when building with `debug = 0`:

```
stack backtrace:
   0: 0x000016fc - __bkpt
   1: 0x00000301 - exception::__cortex_m_rt_PendSV
   2: 0x00000265 - PendSV
      <exception entry>
   3: 0x00001688 - core::ptr::write_volatile
   4: 0x00000439 - cortex_m::peripheral::scb::<impl cortex_m::peripheral::SCB>::set_pendsv
   5: 0x000001c5 - exception::__cortex_m_rt_main
   6: 0x0000012b - main
   7: 0x00001e37 - Reset
```

We'd get stuck at `core::ptr::write_volatile`, since that does not have a Frame Description Entry (FDE). However, that function is trivial, preserves LR, and uses no stack, so we don't need any further info to unwind past it.

This did not occur with `debug = 1` (or higher), since that apparently causes additional instructions to be emitted for `write_volatile`, which in turn makes it need an FDE to properly unwind. It also tends to go away when optimizations are enabled, presumably because (often) no trivial functions are left over after inlining.

(this is my current theory of what goes wrong and could use some more confirmation)