### PR TITLE
Add --no-flash option to probe-run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,13 +42,13 @@ struct Opts {
     #[structopt(long)]
     list_chips: bool,
     #[cfg(feature = "defmt")]
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "no_flash")]
     defmt: bool,
     #[structopt(long, required_unless("list-chips"))]
     chip: Option<String>,
     #[structopt(name = "ELF", parse(from_os_str), required_unless("list-chips"))]
     elf: Option<PathBuf>,
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "defmt")]
     /// Skip writing the application binary to flash
     no_flash: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,9 @@ struct Opts {
     chip: Option<String>,
     #[structopt(name = "ELF", parse(from_os_str), required_unless("list-chips"))]
     elf: Option<PathBuf>,
+    #[structopt(long)]
+    /// Skip writing the application binary to flash
+    no_flash: bool,
 }
 
 fn notmain() -> Result<i32, anyhow::Error> {
@@ -216,10 +219,13 @@ fn notmain() -> Result<i32, anyhow::Error> {
 
         core.run()?;
     } else {
-        // program lives in Flash
-        flashing::download_file(&mut sess, elf_path, Format::Elf)?;
-
-        log::info!("flashed program");
+        if opts.no_flash {
+            log::info!("skipped flashing");
+        } else {
+            // program lives in Flash
+            flashing::download_file(&mut sess, elf_path, Format::Elf)?;
+            log::info!("flashed program");
+        }
 
         let mut core = sess.core(0)?;
         log::info!("attached to core");


### PR DESCRIPTION
Skipping the actual flashing process is useful if the binary to be run
is already in flash, either due being a re-run or use of a different
approach to do the flashing.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>