### PR TITLE
[WIP] Add crate `probe-run-ctrl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
         override: true
+        target: thumbv6m-none-eabi
     - name: Install C libraries for tooling
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,3 @@ jobs:
         cargo build --target thumbv6m-none-eabi
         cargo build --target thumbv6m-none-eabi --features print-rtt
         cargo build --target thumbv6m-none-eabi --features print-defmt
-      # NOTE order is important; running `mdbook` at the end = duplicate crate errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Install C libraries for tooling
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
-    - name: Build
+    - name: Build host tooling
       run: cargo build
+    - name: Build embedded tooling
+      working-directory: panic-probe
+      run: |
+        cargo build --target thumbv6m-none-eabi
+        cargo build --target thumbv6m-none-eabi --features print-rtt
+        cargo build --target thumbv6m-none-eabi --features print-defmt
       # NOTE order is important; running `mdbook` at the end = duplicate crate errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,12 @@ jobs:
     - name: Build host tooling
       run: cargo build
     - name: Build embedded tooling
-      working-directory: panic-probe
       run: |
+        pushd panic-probe
         cargo build --target thumbv6m-none-eabi
         cargo build --target thumbv6m-none-eabi --features print-rtt
         cargo build --target thumbv6m-none-eabi --features print-defmt
+        popd
+        pushd probe-run-ctrl
+        cargo build --target thumbv6m-none-eabi
+        popd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "defmt",
+ "probe-run-ctrl",
  "rtt-target",
 ]
 
@@ -667,6 +668,13 @@ dependencies = [
  "rustc-demangle",
  "structopt",
  "xmas-elf",
+]
+
+[[package]]
+name = "probe-run-ctrl"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#41e229f94d7314f38d5bb2170310fee6b5409782"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#5a1047ba740398184fbe26b58fe504c0b918c6bb"
 
 [[package]]
 name = "cortex-m"
@@ -210,7 +210,7 @@ dependencies = [
 [[package]]
 name = "decoder"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#41e229f94d7314f38d5bb2170310fee6b5409782"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#5a1047ba740398184fbe26b58fe504c0b918c6bb"
 dependencies = [
  "byteorder",
  "colored",
@@ -221,9 +221,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "0.1.0"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#5a1047ba740398184fbe26b58fe504c0b918c6bb"
+dependencies = [
+ "common",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.1.0"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#5a1047ba740398184fbe26b58fe504c0b918c6bb"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "defmt-parser"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#41e229f94d7314f38d5bb2170310fee6b5409782"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#5a1047ba740398184fbe26b58fe504c0b918c6bb"
 
 [[package]]
 name = "derivative"
@@ -245,7 +265,7 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 [[package]]
 name = "elf2table"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#41e229f94d7314f38d5bb2170310fee6b5409782"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#5a1047ba740398184fbe26b58fe504c0b918c6bb"
 dependencies = [
  "anyhow",
  "decoder",
@@ -508,9 +528,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
 dependencies = [
  "adler",
 ]
@@ -559,6 +579,8 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
+ "defmt",
+ "rtt-target",
 ]
 
 [[package]]
@@ -732,6 +754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
+name = "rtt-target"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0869b4c5b6a6d8c5583fc473f9eb3423a170f77626b8c8a7fb18eddcda5770e2"
+dependencies = [
+ "ufmt-write",
+]
+
+[[package]]
 name = "rusb"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,9 +904,9 @@ checksum = "3685c82a045a6af0c488f0550b0f52b4c77d2a52b0ca8aba719f9d268fa96965"
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -952,6 +983,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19796bd8d477f1a9d4ac2465b464a8b1359474f06a96bb3cda650b4fca309bf"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +52,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "as-slice"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
+dependencies = [
+ "generic-array 0.12.3",
+ "generic-array 0.13.2",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +78,15 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "base64"
@@ -125,6 +154,39 @@ dependencies = [
 name = "common"
 version = "0.1.0"
 source = "git+https://github.com/knurling-rs/defmt?branch=main#41e229f94d7314f38d5bb2170310fee6b5409782"
+
+[[package]]
+name = "cortex-m"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be99930c99669a74d986f7fd2162085498b322e6daae8ef63a97cc9ac1dc73c"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-rt"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d518da72bba39496024b62607c1d8e37bcece44b2536664f1132a73a499a28"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4717562afbba06e760d34451919f5c3bf3ac15c7bb897e8b04862a7428378647"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "crc32fast"
@@ -242,6 +304,24 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -474,6 +554,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 
 [[package]]
+name = "panic-probe"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +748,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +781,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -830,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +970,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "vcell"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876e32dcadfe563a4289e994f7cb391197f362b6315dc45e8ba4aa6f564a4b3c"
 
 [[package]]
 name = "vcpkg"
@@ -870,6 +1000,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ xmas-elf = "0.7.0"
 
 [features]
 defmt = ["elf2table", "decoder"]
+
+[workspace]
+members = ["panic-probe"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ xmas-elf = "0.7.0"
 defmt = ["elf2table", "decoder"]
 
 [workspace]
-members = ["panic-probe"]
+members = ["panic-probe", "probe-run-ctrl"]

--- a/panic-probe/Cargo.toml
+++ b/panic-probe/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "panic-probe"
 version = "0.1.0"
-authors = ["Jorge Aparicio <jorge.aparicio@ferrous-systems.com>"]
+authors = ["The Knurling Authors"]
 edition = "2018"
 description = "Panic handler that exits `probe-run` with an error code"
 

--- a/panic-probe/Cargo.toml
+++ b/panic-probe/Cargo.toml
@@ -8,3 +8,20 @@ description = "Panic handler that exits `probe-run` with an error code"
 [dependencies]
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
+
+[dependencies.rtt-target]
+version = "0.2.2"
+optional = true
+
+[dependencies.defmt]
+git = "https://github.com/knurling-rs/defmt.git"
+branch = "main"
+optional = true
+
+[features]
+# Print the panic message using `rtt-target`.
+print-rtt = ["rtt-target"]
+# Print the panic message using `defmt`.
+print-defmt = ["defmt", "defmt-error"]
+
+defmt-error = [] # internal feature, do not use

--- a/panic-probe/Cargo.toml
+++ b/panic-probe/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "panic-probe"
+version = "0.1.0"
+authors = ["Jorge Aparicio <jorge.aparicio@ferrous-systems.com>"]
+edition = "2018"
+description = "Panic handler that exits `probe-run` with an error code"
+
+[dependencies]
+cortex-m = "0.6.3"
+cortex-m-rt = "0.6.12"

--- a/panic-probe/Cargo.toml
+++ b/panic-probe/Cargo.toml
@@ -8,6 +8,7 @@ description = "Panic handler that exits `probe-run` with an error code"
 [dependencies]
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
+probe-run-ctrl = { path = "../probe-run-ctrl", version = "0.1.0" }
 
 [dependencies.rtt-target]
 version = "0.2.2"

--- a/panic-probe/build.rs
+++ b/panic-probe/build.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    if target.starts_with("thumbv6m-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv6m");
+    } else if target.starts_with("thumbv7m-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv7m");
+    } else if target.starts_with("thumbv7em-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv7m");
+        println!("cargo:rustc-cfg=armv7em"); // (not currently used)
+    } else if target.starts_with("thumbv8m.base") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv8m");
+        println!("cargo:rustc-cfg=armv8m_base");
+    } else if target.starts_with("thumbv8m.main") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv8m");
+        println!("cargo:rustc-cfg=armv8m_main");
+    }
+}

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -148,6 +148,6 @@ mod print_defmt {
 
         let msg = str::from_utf8(&sink.buf[..sink.pos]).unwrap_or("<utf-8 error>");
         let overflow = if sink.overflowed { OVERFLOW_MARK } else { "" };
-        defmt::error!("panic-probe: {:str}{:str}", msg, overflow);
+        defmt::error!("{:str}{:str}", msg, overflow);
     }
 }

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -46,6 +46,8 @@ mod imp {
     fn panic(info: &PanicInfo) -> ! {
         static PANICKED: AtomicBool = AtomicBool::new(false);
 
+        cortex_m::interrupt::disable();
+
         // Guard against infinite recursion, just in case.
         if PANICKED.load(Ordering::Relaxed) {
             loop {

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -1,0 +1,36 @@
+//! Panic handler for `probe-run`.
+//!
+//! When this panic handler is used, panics will make `probe-run` print a backtrace and exit with a
+//! non-zero status code, indicating failure. This building block can be used to run on-device
+//! tests.
+//!
+//! This crate also overrides the Cortex-M HardFault handler: Any HardFault will also cause
+//! `probe-run` to exit with an error code.
+//!
+//! **Note**: The panic message (if any) is currently ignored.
+
+#![no_std]
+
+// Functionality `cfg`d out on platforms with OS/libstd.
+#[cfg(target_os = "none")]
+mod imp {
+    use core::panic::PanicInfo;
+
+    use cortex_m::asm;
+    use cortex_m_rt::{exception, ExceptionFrame};
+
+    #[panic_handler]
+    fn panic(_: &PanicInfo) -> ! {
+        // Trigger a `HardFault`.
+        // FIXME: This will actually cause a `UsageFault` if that's enabled!
+        asm::udf();
+    }
+
+    #[exception]
+    fn HardFault(_: &ExceptionFrame) -> ! {
+        loop {
+            // Make `probe-run` print the backtrace and exit.
+            asm::bkpt();
+        }
+    }
+}

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -7,7 +7,17 @@
 //! This crate also overrides the Cortex-M HardFault handler: Any HardFault will also cause
 //! `probe-run` to exit with an error code.
 //!
-//! **Note**: The panic message (if any) is currently ignored.
+//! # Panic Messages
+//!
+//! By default, `panic-probe` *ignores* the panic message. You can enable one of the following
+//! features to print it instead:
+//!
+//! - `print-rtt`: Prints the panic message over plain RTT (via `rtt-target`). RTT must be
+//!   initialized by the app.
+//! - `print-defmt`: Prints the panic message via [defmt]'s transport (note that defmt will not be
+//!   used to efficiently format the message).
+//!
+//! [defmt]: https://github.com/knurling-rs/defmt/
 
 #![no_std]
 
@@ -18,12 +28,35 @@ compile_error!("`panic-probe` only supports Cortex-M targets (thumbvN-none-eabi[
 #[cfg(target_os = "none")]
 mod imp {
     use core::panic::PanicInfo;
+    use core::sync::atomic::{AtomicBool, Ordering};
 
     use cortex_m::asm;
     use cortex_m_rt::{exception, ExceptionFrame};
 
+    #[cfg(feature = "print-rtt")]
+    use crate::print_rtt::print;
+
+    #[cfg(feature = "print-defmt")]
+    use crate::print_defmt::print;
+
+    #[cfg(not(any(feature = "print-rtt", feature = "print-defmt")))]
+    fn print(_: &core::panic::PanicInfo) {}
+
     #[panic_handler]
-    fn panic(_: &PanicInfo) -> ! {
+    fn panic(info: &PanicInfo) -> ! {
+        static PANICKED: AtomicBool = AtomicBool::new(false);
+
+        // Guard against infinite recursion, just in case.
+        if PANICKED.load(Ordering::Relaxed) {
+            loop {
+                asm::bkpt();
+            }
+        }
+
+        PANICKED.store(true, Ordering::Relaxed);
+
+        print(info);
+
         // Trigger a `HardFault` via `udf` instruction.
 
         // If `UsageFault` is enabled, we disable that first, since otherwise `udf` will cause that
@@ -49,5 +82,70 @@ mod imp {
             // Make `probe-run` print the backtrace and exit.
             asm::bkpt();
         }
+    }
+}
+
+#[cfg(feature = "print-rtt")]
+mod print_rtt {
+    use core::panic::PanicInfo;
+    use rtt_target::rprintln;
+
+    pub fn print(info: &PanicInfo) {
+        rprintln!("{}", info);
+    }
+}
+
+#[cfg(feature = "print-defmt")]
+mod print_defmt {
+    use core::{
+        cmp,
+        fmt::{self, Write},
+        mem,
+        panic::PanicInfo,
+        str,
+    };
+
+    const DEFMT_BUF_SIZE: usize = 128;
+    const OVERFLOW_MARK: &str = "…";
+
+    struct Sink<'a> {
+        buf: &'a mut [u8],
+        pos: usize,
+        overflowed: bool,
+    }
+
+    impl<'a> fmt::Write for Sink<'a> {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            if self.overflowed {
+                return Ok(());
+            }
+
+            let buf = mem::replace(&mut self.buf, &mut []);
+            let buf_unused = &mut buf[self.pos..];
+
+            if buf_unused.len() < s.len() {
+                self.overflowed = true;
+            }
+
+            let lim = cmp::min(buf_unused.len(), s.len());
+            buf_unused[..lim].copy_from_slice(&s.as_bytes()[..lim]);
+            self.buf = buf;
+            self.pos += lim;
+            Ok(())
+        }
+    }
+
+    pub fn print(info: &PanicInfo) {
+        let mut buf = [0; DEFMT_BUF_SIZE];
+        let mut sink = Sink {
+            buf: &mut buf,
+            pos: 0,
+            overflowed: false,
+        };
+        write!(sink, "{}", info).ok();
+
+        let msg = str::from_utf8(&sink.buf[..sink.pos]).unwrap_or("<utf-8 error>");
+        let overflow = if sink.overflowed { OVERFLOW_MARK } else { "" };
+        defmt::error!("panic-probe: {:str}{:str}", msg, overflow);
     }
 }

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -75,15 +75,12 @@ mod imp {
             }
         }
 
-        asm::udf();
+        probe_run_ctrl::abort();
     }
 
     #[exception]
     fn HardFault(_: &ExceptionFrame) -> ! {
-        loop {
-            // Make `probe-run` print the backtrace and exit.
-            asm::bkpt();
-        }
+        probe_run_ctrl::abort();
     }
 }
 

--- a/probe-run-ctrl/Cargo.toml
+++ b/probe-run-ctrl/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "probe-run-ctrl"
+version = "0.1.0"
+authors = ["The Knurling Authors"]
+edition = "2018"
+description = "Control `probe-run` from an embedded app"
+categories = ["command-line-utilities", "embedded", "no-std"]
+keywords = ["knurling", "probe", "host"]
+license = "MIT OR Apache-2.0"
+readme = "../README.md"
+repository = "https://github.com/knurling-rs/probe-run"
+
+[dependencies]
+cortex-m = "0.6.3"

--- a/probe-run-ctrl/build.rs
+++ b/probe-run-ctrl/build.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    if target.starts_with("thumbv6m-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv6m");
+    } else if target.starts_with("thumbv7m-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv7m");
+    } else if target.starts_with("thumbv7em-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv7m");
+        println!("cargo:rustc-cfg=armv7em"); // (not currently used)
+    } else if target.starts_with("thumbv8m.base") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv8m");
+        println!("cargo:rustc-cfg=armv8m_base");
+    } else if target.starts_with("thumbv8m.main") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv8m");
+        println!("cargo:rustc-cfg=armv8m_main");
+    }
+}

--- a/probe-run-ctrl/src/lib.rs
+++ b/probe-run-ctrl/src/lib.rs
@@ -1,0 +1,25 @@
+//! Control a `probe-run` process on the host computer from an embedded app.
+
+#![no_std]
+
+use cortex_m::asm;
+
+/// Exits the `probe-run` host process with a success status.
+pub fn exit() -> ! {
+    loop {
+        asm::bkpt();
+    }
+}
+
+/// Exits the `probe-run` host process with an error status.
+pub fn abort() -> ! {
+    #[inline(never)] // ensure that this always has its own stack frame
+    #[no_mangle]
+    fn __probe_run_internal_abort() -> ! {
+        loop {
+            asm::bkpt();
+        }
+    }
+
+    __probe_run_internal_abort();
+}


### PR DESCRIPTION
(this still needs to be implemented in probe-run, but I wanted to gather feedback first)

This provides a canonical way to terminate the host's `probe-run` process with either a success and failure status. While `panic-probe` does this automatically in the case of panics and HardFaults, the `probe-run-ctrl` crate can also be used directly to abort probe-run. This makes it more convenient to write custom panic handlers etc. that want to terminate `probe-run`.

Based on #18, only the last commit is new.