### PR TITLE
Allow environment variables to set chip arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ Add this line to your Cargo configuration (`.cargo/config`) file:
 
 ``` toml
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip $CHIP"
+runner = "probe-run --chip ${PROBE_RUN_CHIP}"
 ```
 
-Instead of `$CHIP` you'll need to write the name of your microcontroller.
+Instead of `${PROBE_RUN_CHIP}` you can write the name of your microcontroller.
 For example, one would use `nRF52840_xxAA` for the nRF52840 microcontroller.
 To list all supported chips run `probe-run --list-chips`.
+
+To support multiple devices, or permit overriding default behavior, you may prefer to set the
+`${PROBE_RUN_CHIP}` environment variable, and set `runner` (or
+`CARGO_TARGET_${TARGET_ARCH}_RUNNER`) to `probe-run`.
 
 2. Enable debug info
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ struct Opts {
     chip: Option<String>,
 
     /// Path to an ELF firmware file.
-    #[structopt(name = "ELF", parse(from_os_str), required_unless("list-chips"), env = "PROBE_RUN_ELF")]
+    #[structopt(name = "ELF", parse(from_os_str), required_unless("list-chips"))]
     elf: Option<PathBuf>,
 
     /// Skip writing the application binary to flash.

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,11 +51,11 @@ struct Opts {
     defmt: bool,
 
     /// The chip to program.
-    #[structopt(long, required_unless("list-chips"))]
+    #[structopt(long, required_unless("list-chips"), env = "PROBE_RUN_CHIP")]
     chip: Option<String>,
 
     /// Path to an ELF firmware file.
-    #[structopt(name = "ELF", parse(from_os_str), required_unless("list-chips"))]
+    #[structopt(name = "ELF", parse(from_os_str), required_unless("list-chips"), env = "PROBE_RUN_ELF")]
     elf: Option<PathBuf>,
 
     /// Skip writing the application binary to flash.


### PR DESCRIPTION
This small change makes allowing build tooling to configure the passed chip a bit easier. I also did `elf` because it was... well, it was there. I'd be very happy to remove that change if desired.

It also educates the user on how to use the new feature, and ways they might leverage it.