### PR TITLE
Better diagnostic when linker script was missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,13 @@ fn notmain() -> Result<i32, anyhow::Error> {
         );
     }
 
+    elf.find_section_by_name(".text").ok_or_else(|| {
+        anyhow!(
+            "`.text` section is missing, please make sure that the linker script \
+            was passed to the linker"
+        )
+    })?;
+
     #[cfg(feature = "defmt")]
     let (table, locs) = {
         let table = elf2table::parse(&bytes)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,8 @@ fn notmain() -> Result<i32, anyhow::Error> {
 
     elf.find_section_by_name(".text").ok_or_else(|| {
         anyhow!(
-            "`.text` section is missing, please make sure that the linker script \
-            was passed to the linker"
+            "`.text` section is missing, please make sure that the linker script was passed to the \
+            linker (check `.cargo/config.toml` and the `RUSTFLAGS` variable)"
         )
     })?;
 


### PR DESCRIPTION
Before:

```
Error: .`.defmt` section not found
```

After:

```
Error: `.text` section is missing, please make sure that the linker script was passed to the linker
```

Closes #42 