### PR TITLE
Improve CLI output formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
     - name: Build host tooling
-      run: cargo build
+      run: |
+        cargo build
+        cargo build --features defmt
     - name: Build embedded tooling
       working-directory: panic-probe
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,11 +157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt.git?branch=main#0af5bd2ccc70bcfb88fc9cbcc06be402a08baef1"
-
-[[package]]
 name = "cortex-m"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,31 +199,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "decoder"
+name = "defmt"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt.git?branch=main#0af5bd2ccc70bcfb88fc9cbcc06be402a08baef1"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#8a16c2c3080c0f11ddd4bb52cffe2deb037363a5"
+dependencies = [
+ "defmt-common",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-common"
+version = "0.1.0"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#8a16c2c3080c0f11ddd4bb52cffe2deb037363a5"
+
+[[package]]
+name = "defmt-decoder"
+version = "0.1.0"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#8a16c2c3080c0f11ddd4bb52cffe2deb037363a5"
 dependencies = [
  "byteorder",
  "colored",
- "common",
+ "defmt-common",
  "defmt-parser",
  "leb128",
  "ryu",
 ]
 
 [[package]]
-name = "defmt"
+name = "defmt-elf2table"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt.git?branch=main#0af5bd2ccc70bcfb88fc9cbcc06be402a08baef1"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#8a16c2c3080c0f11ddd4bb52cffe2deb037363a5"
 dependencies = [
- "common",
- "defmt-macros",
+ "anyhow",
+ "defmt-decoder",
+ "gimli 0.22.0",
+ "object 0.21.1",
 ]
 
 [[package]]
 name = "defmt-macros"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt.git?branch=main#0af5bd2ccc70bcfb88fc9cbcc06be402a08baef1"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#8a16c2c3080c0f11ddd4bb52cffe2deb037363a5"
 dependencies = [
  "defmt-parser",
  "proc-macro2",
@@ -239,7 +250,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt.git?branch=main#0af5bd2ccc70bcfb88fc9cbcc06be402a08baef1"
+source = "git+https://github.com/knurling-rs/defmt.git?branch=main#8a16c2c3080c0f11ddd4bb52cffe2deb037363a5"
 
 [[package]]
 name = "derivative"
@@ -257,17 +268,6 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-
-[[package]]
-name = "elf2table"
-version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt.git?branch=main#0af5bd2ccc70bcfb88fc9cbcc06be402a08baef1"
-dependencies = [
- "anyhow",
- "decoder",
- "gimli 0.22.0",
- "object 0.21.1",
-]
 
 [[package]]
 name = "enum-primitive-derive"
@@ -645,8 +645,8 @@ dependencies = [
  "anyhow",
  "arrayref",
  "colored",
- "decoder",
- "elf2table",
+ "defmt-decoder",
+ "defmt-elf2table",
  "env_logger",
  "gimli 0.22.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ anyhow = "1.0.32"
 arrayref = "0.3.6"
 colored = "2.0.0"
 signal-hook = "0.1.16"
-decoder = { git = "https://github.com/knurling-rs/defmt", branch = "main", optional = true }
-elf2table = { git = "https://github.com/knurling-rs/defmt", branch = "main", optional = true }
+defmt-decoder = { git = "https://github.com/knurling-rs/defmt", branch = "main", optional = true }
+defmt-elf2table = { git = "https://github.com/knurling-rs/defmt", branch = "main", optional = true }
 env_logger = "0.7.1"
 gimli = "0.22.0"
 log = "0.4.11"
@@ -27,7 +27,7 @@ structopt = "0.3.15"
 object = "0.21.1"
 
 [features]
-defmt = ["elf2table", "decoder"]
+defmt = ["defmt-elf2table", "defmt-decoder"]
 
 [workspace]
 members = ["panic-probe"]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,147 @@
+use colored::{Color, Colorize};
+#[cfg(feature = "defmt")]
+use decoder::Frame;
+use io::Write;
+use log::{Level, Log, Metadata, Record};
+use std::{
+    io,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+const DEFMT_TARGET_MARKER: &str = "defmt@";
+
+/// Initializes the `probe-run` logger.
+pub fn init(verbose: bool) {
+    log::set_boxed_logger(Box::new(Logger {
+        verbose,
+        timing_align: AtomicUsize::new(8),
+    }))
+    .unwrap();
+    log::set_max_level(log::LevelFilter::Trace);
+}
+
+/// Logs a defmt frame using the `log` facade.
+#[cfg(feature = "defmt")]
+pub fn log_defmt(
+    frame: &Frame<'_>,
+    file: Option<&str>,
+    line: Option<u32>,
+    module_path: Option<&str>,
+) {
+    let level = match frame.level() {
+        decoder::Level::Trace => Level::Trace,
+        decoder::Level::Debug => Level::Debug,
+        decoder::Level::Info => Level::Info,
+        decoder::Level::Warn => Level::Warn,
+        decoder::Level::Error => Level::Error,
+    };
+
+    let target = format!("{}{}", DEFMT_TARGET_MARKER, frame.timestamp());
+    let display = frame.display_message();
+
+    log::logger().log(
+        &Record::builder()
+            .args(format_args!("{}", display))
+            .level(level)
+            .target(&target)
+            .module_path(module_path)
+            .file(file)
+            .line(line)
+            .build(),
+    );
+}
+
+struct Logger {
+    /// Whether to log `debug!` and `trace!`-level host messages.
+    verbose: bool,
+
+    /// Number of characters used by the timestamp. This may increase over time and is used to align
+    /// messages.
+    timing_align: AtomicUsize,
+}
+
+impl Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        if metadata.target().starts_with(DEFMT_TARGET_MARKER) {
+            // defmt is configured at firmware-level, we will print all of it.
+            true
+        } else {
+            // Host logs use `info!` as the default level, but with the `verbose` flag set we log at
+            // `trace!` level instead.
+            if self.verbose {
+                metadata.target().starts_with("probe_run")
+            } else {
+                metadata.target().starts_with("probe_run") && metadata.level() <= Level::Info
+            }
+        }
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let level_color = match record.level() {
+            Level::Error => Color::Red,
+            Level::Warn => Color::Yellow,
+            Level::Info => Color::Green,
+            Level::Debug => Color::BrightWhite,
+            Level::Trace => Color::BrightBlack,
+        };
+
+        let target = record.metadata().target();
+        let is_defmt = target.starts_with(DEFMT_TARGET_MARKER);
+
+        let timestamp = if is_defmt {
+            let timestamp = target[DEFMT_TARGET_MARKER.len()..].parse::<u64>().unwrap();
+            let seconds = timestamp / 1000000;
+            let micros = timestamp % 1000000;
+            format!("{}.{:06}", seconds, micros)
+        } else {
+            // Mark host logs.
+            format!("(HOST)")
+        };
+
+        let mod_path = record.module_path().unwrap_or("");
+
+        self.timing_align
+            .fetch_max(timestamp.len(), Ordering::Relaxed);
+
+        let (stdout, stderr, mut stdout_lock, mut stderr_lock);
+        let sink: &mut dyn Write = if is_defmt {
+            // defmt goes to stdout, since it's the primary output produced by this tool.
+            stdout = io::stdout();
+            stdout_lock = stdout.lock();
+            &mut stdout_lock
+        } else {
+            // Everything else goes to stderr.
+            stderr = io::stderr();
+            stderr_lock = stderr.lock();
+            &mut stderr_lock
+        };
+
+        writeln!(
+            sink,
+            "{timestamp:>0$} {level:5} {module:9} | {args}",
+            self.timing_align.load(Ordering::Relaxed),
+            timestamp = timestamp,
+            level = record.level().to_string().color(level_color),
+            module = mod_path,
+            args = record.args(),
+        )
+        .ok();
+
+        if let Some(file) = record.file() {
+            // Always include location info for defmt output.
+            if is_defmt || self.verbose {
+                let mut loc = file.to_string();
+                if let Some(line) = record.line() {
+                    loc.push_str(&format!(":{}", line));
+                }
+                writeln!(sink, "└─ {}", loc.dimmed()).ok();
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,6 @@
 use colored::{Color, Colorize};
 #[cfg(feature = "defmt")]
-use decoder::Frame;
+use defmt_decoder::Frame;
 use io::Write;
 use log::{Level, Log, Metadata, Record};
 use std::{
@@ -29,11 +29,11 @@ pub fn log_defmt(
     module_path: Option<&str>,
 ) {
     let level = match frame.level() {
-        decoder::Level::Trace => Level::Trace,
-        decoder::Level::Debug => Level::Debug,
-        decoder::Level::Info => Level::Info,
-        decoder::Level::Warn => Level::Warn,
-        decoder::Level::Error => Level::Error,
+        defmt_decoder::Level::Trace => Level::Trace,
+        defmt_decoder::Level::Debug => Level::Debug,
+        defmt_decoder::Level::Info => Level::Info,
+        defmt_decoder::Level::Warn => Level::Warn,
+        defmt_decoder::Level::Error => Level::Error,
     };
 
     let target = format!("{}{}", DEFMT_TARGET_MARKER, frame.timestamp());

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
 
     #[cfg(feature = "defmt")]
     let (table, locs) = {
-        let table = elf2table::parse(&bytes)?;
+        let table = defmt_elf2table::parse(&bytes)?;
 
         if table.is_none() && opts.defmt {
             bail!("`.defmt` section not found")
@@ -142,7 +142,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
 
         let locs = if opts.defmt {
             let table = table.as_ref().unwrap();
-            let locs = elf2table::get_locations(&bytes)?;
+            let locs = defmt_elf2table::get_locations(&bytes)?;
 
             if !table.is_empty() && locs.is_empty() {
                 log::warn!("insufficient DWARF info; compile your program with `debug = 2` to enable location info");
@@ -336,7 +336,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
                             frames.extend_from_slice(&read_buf[..num_bytes_read]);
 
                             while let Ok((frame, consumed)) =
-                                decoder::decode(&frames, table.as_ref().unwrap())
+                                defmt_decoder::decode(&frames, table.as_ref().unwrap())
                             {
                                 // NOTE(`[]` indexing) all indices in `table` have already been
                                 // verified to exist in the `locs` map


### PR DESCRIPTION
Depends on https://github.com/knurling-rs/defmt/pull/158.

New output:

```
  (HOST) WARN  probe_run | (BUG) location info is incomplete; it will be omitted from the output
  (HOST) INFO  probe_run | flashing program
  (HOST) INFO  probe_run | done!
────────────────────────────────────────────────────────────────────────────────
0.000002 INFO            | Hello!
0.000092 INFO            | World!
0.000182 INFO            | The answer is 42
0.000304 INFO            | S { x: 1, y: 256 }
0.000488 INFO            | X { y: Y { z: 42 } }
stack backtrace:
   0: 0x00000dd2 - __bkpt
   1: 0x000007a8 - log::__cortex_m_rt_main
   2: 0x0000047a - main
   3: 0x00002ab2 - Reset
```