### PR TITLE
set a HW breakpoint on the hard fault handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "aligned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,19 +272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,15 +391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "ihex"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,12 +485,6 @@ checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "memchr"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "miniz_oxide"
@@ -647,7 +610,6 @@ dependencies = [
  "colored",
  "defmt-decoder",
  "defmt-elf2table",
- "env_logger",
  "gimli 0.22.0",
  "log",
  "object 0.21.1",
@@ -692,12 +654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,24 +673,6 @@ name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "regex"
-version = "1.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
- "thread_local",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "rle-decode-fast"
@@ -941,15 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,15 +905,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -1071,15 +991,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,38 @@ stack backtrace:
 3: 0x000005ee - Reset
 ```
 
+## Non-zero exit code
+
+When the device raises a hard fault exception `probe-run` will print a backtrace
+and exit with non-zero exit code.
+
+You can trigger a hard fault exception with the UDF instruction.
+
+``` rust
+use cortex_m::asm;
+#[entry]
+fn main() -> ! {
+    asm::udf()
+}
+```
+
+``` console
+$ cargo run --bin hard-fault
+stack backtrace:
+   0: 0x000003e0 - HardFaultTrampoline
+      <exception entry>
+   1: 0x00000140 - __udf
+   2: 0x00000118 - cortex_m::asm::udf
+   3: 0x0000012c - hard_fault::__cortex_m_rt_main
+   4: 0x00000122 - main
+   5: 0x000000fa - Reset
+
+$ echo $?
+134
+```
+
+**NOTE** when you run your application with `probe-run` the `HardFault` handler,
+default or user-defined one, will *NOT* be executed.
 
 ## Support
 

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -4,9 +4,6 @@
 //! non-zero status code, indicating failure. This building block can be used to run on-device
 //! tests.
 //!
-//! This crate also overrides the Cortex-M HardFault handler: Any HardFault will also cause
-//! `probe-run` to exit with an error code.
-//!
 //! # Panic Messages
 //!
 //! By default, `panic-probe` *ignores* the panic message. You can enable one of the following
@@ -76,14 +73,6 @@ mod imp {
         }
 
         asm::udf();
-    }
-
-    #[exception]
-    fn HardFault(_: &ExceptionFrame) -> ! {
-        loop {
-            // Make `probe-run` print the backtrace and exit.
-            asm::bkpt();
-        }
     }
 }
 

--- a/panic-probe/src/lib.rs
+++ b/panic-probe/src/lib.rs
@@ -28,7 +28,6 @@ mod imp {
     use core::sync::atomic::{AtomicBool, Ordering};
 
     use cortex_m::asm;
-    use cortex_m_rt::{exception, ExceptionFrame};
 
     #[cfg(feature = "print-rtt")]
     use crate::print_rtt::print;

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,7 +451,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
     Ok(
         if let Some(TopException::HardFault { stack_overflow }) = top_exception {
             if stack_overflow {
-                println!("{}", "!!!! STACK OVERFLOW DETECTED !!!!".red().bold());
+                log::error!("the program has overflowed its stack");
             }
 
             SIGABRT

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,7 +296,11 @@ fn notmain() -> Result<i32, anyhow::Error> {
         }
 
         log::debug!("starting device");
-        core.set_hw_breakpoint(vector_table.hard_fault)?;
+        if core.get_available_breakpoint_units()? == 0 {
+            log::warn!("device doesn't support HW breakpoints; HardFault will NOT make `probe-run` exit with an error code");
+        } else {
+            core.set_hw_breakpoint(vector_table.hard_fault)?;
+        }
         core.run()?;
     }
 


### PR DESCRIPTION
reaching that breakpoint makes `probe-run` exit with an error code
also remove the HardFault override as it's no longer needed

motivation: the current HardFault override uses the stack. when stack overflows are routed to a hard fault exception that results in the HardFault handler being called recursively and to the user `probe-run` will appear to hang (this is the because the micro will be executing an infinite (recursive) loop)

downside: using `probe-run` with or without `panic-probe` = HardFault (either the default one or a user defined one) never runs. which may be confusing but can be documented ("changes in behavior" section)

TODO:
- [x] ~~test behavior on ARM Cortex-M0+~~ works without a hitch

FIXME:
- [x] ~~the first frame of the backtrace is reported as `<unknown>` but should say `HardFaultTrampoline`~~ upstream issue in cortex-m-rt; fix PR has been submitted
``` console
$ cargo rb panic
stack backtrace:
   0: 0x000007de - <unknown>
   1: 0x00000656 - rust_begin_unwind
   2: 0x00000616 - core::panicking::panic_fmt
   3: 0x000005f0 - core::panicking::panic
   4: 0x0000017c - panic::__cortex_m_rt_main
   5: 0x00000108 - main
   6: 0x000007d6 - ResetTrampoline
   7: 0x000007cc - Reset
```