### PR TITLE
stack overflow detection: adjust for full descending stacks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
         .iter()
         .filter_map(|region| match region {
             MemoryRegion::Ram(region) => {
-                // NOTE stack is full descending; meaning the stack point can be `ORIGIN(RAM) +
+                // NOTE stack is full descending; meaning the stack pointer can be `ORIGIN(RAM) +
                 // LENGTH(RAM)`
                 let range = region.range.start..=region.range.end;
                 if range.contains(&vector_table.initial_sp) {
@@ -635,7 +635,7 @@ fn backtrace(
                 println!("      <exception entry>");
 
                 let stack_overflow = if let Some(sp_ram_region) = sp_ram_region {
-                    // NOTE stack is full descending; meaning the stack point can be `ORIGIN(RAM) +
+                    // NOTE stack is full descending; meaning the stack pointer can be `ORIGIN(RAM) +
                     // LENGTH(RAM)`
                     let range = sp_ram_region.range.start..=sp_ram_region.range.end;
                     !range.contains(&sp)


### PR DESCRIPTION
in the ARM ISA the stack is of the full descending type, meaning that the
initial stack pointer will appear to be "outside" the RAM region: that is start
at `ORIGIN(RAM) + LENGTH(RAM)`
this is particularly the case when the stack overflow protection has not been
added (the stack is not flipped)
so adjust the logic accordingly

fixes: `probe-run` was printing the warning message shown below when the program panicked
``` text
  (HOST) WARN  probe_run | no RAM region appears to contain the stack; cannot determine if this was a stack overflow
```