### PR TITLE
tweak output format

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -102,8 +102,6 @@ impl Log for Logger {
             format!("(HOST)")
         };
 
-        let mod_path = record.module_path().unwrap_or("");
-
         self.timing_align
             .fetch_max(timestamp.len(), Ordering::Relaxed);
 
@@ -122,23 +120,31 @@ impl Log for Logger {
 
         writeln!(
             sink,
-            "{timestamp:>0$} {level:5} {module:9} | {args}",
+            "{timestamp:>0$} {level:5} {args}",
             self.timing_align.load(Ordering::Relaxed),
             timestamp = timestamp,
             level = record.level().to_string().color(level_color),
-            module = mod_path,
-            args = record.args(),
+            args = record.args().to_string().bold(),
         )
         .ok();
 
         if let Some(file) = record.file() {
+            // NOTE will be `Some` if `file` is `Some`
+            let mod_path = record.module_path().unwrap();
             // Always include location info for defmt output.
             if is_defmt || self.verbose {
                 let mut loc = file.to_string();
                 if let Some(line) = record.line() {
                     loc.push_str(&format!(":{}", line));
                 }
-                writeln!(sink, "└─ {}", loc.dimmed()).ok();
+                writeln!(
+                    sink,
+                    "└─ {} {} {}",
+                    mod_path.dimmed(),
+                    "@".dimmed(),
+                    loc.dimmed()
+                )
+                .ok();
             }
         }
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -137,14 +137,7 @@ impl Log for Logger {
                 if let Some(line) = record.line() {
                     loc.push_str(&format!(":{}", line));
                 }
-                writeln!(
-                    sink,
-                    "└─ {} {} {}",
-                    mod_path.dimmed(),
-                    "@".dimmed(),
-                    loc.dimmed()
-                )
-                .ok();
+                writeln!(sink, "{}", format!("└─ {} @ {}", mod_path, loc).dimmed()).ok();
             }
         }
     }


### PR DESCRIPTION
- moves module path to the next line (same line as the file location)
- makes the log message bold (the part after the log level)

pros:
- the start of the log messages is now aligned

cons:
- second line becomes even longer

![2020-09-08-165430](https://user-images.githubusercontent.com/5018213/92492840-1c758700-f1f4-11ea-9916-af7bfe052254.png)