### PR TITLE
place breakpoint on an even address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -317,7 +317,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
         if core.get_available_breakpoint_units()? == 0 {
             log::warn!("device doesn't support HW breakpoints; HardFault will NOT make `probe-run` exit with an error code");
         } else {
-            core.set_hw_breakpoint(vector_table.hard_fault)?;
+            core.set_hw_breakpoint(vector_table.hard_fault & !THUMB_BIT)?;
         }
         core.run()?;
     }


### PR DESCRIPTION
that is clear the thumb bit of the address before passing it to
`set_hw_breakpoint`

fixes a bug (\*) where the microcontroller will pause at the *second*
instruction of `HardFaultTrampoline` rather than the first
Observed with these values:
- `vector_table.hard_fault` = 0x7dc
- PC read at breakpoint (in `backtrace`) = 0x7de
``` armasm
000007dc <HardFaultTrampoline>:
 7dc:   4670            mov     r0, lr
 7de:   2104            movs    r1, #4
```
(\*) observed bug behavior: `<exception entry>` was not printed and exit code
was 0 (instead of SIGABRT)