### PR TITLE
flush after each stdout write when defmt is not enabled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
                     #[cfg(not(feature = "defmt"))]
                     () => {
                         stdout.write_all(&read_buf[..num_bytes_read])?;
+                        stdout.flush()?;
                     }
                 }
             }


### PR DESCRIPTION
terminal apps flush on newline by default (changing that is not straightforward
iirc)
so instead we flush after each write call so that data not containing a newline
is printed immediately
should fix #75