### PR TITLE
add git info to --version output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
-use core::str;
-use std::{env, error::Error, fs, path::PathBuf, process::Command};
+use std::{env, error::Error, fs, path::PathBuf, process::Command, str};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let out = &PathBuf::from(env::var("OUT_DIR")?);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use core::str;
+use std::{env, error::Error, fs, path::PathBuf, process::Command};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out = &PathBuf::from(env::var("OUT_DIR")?);
+    // NOTE(unwrap_or) user may not have `git` installed or this may be a crates.io checkout; don't
+    // error in either case; just report an empty string
+    fs::write(
+        out.join("git-info.txt"),
+        git_info().unwrap_or(String::new()),
+    )?;
+
+    Ok(())
+}
+
+fn git_info() -> Result<String, Box<dyn Error>> {
+    let hash = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()?;
+    let date = Command::new("git")
+        .args(&["log", "-1", "--format=%cs"])
+        .output()?;
+
+    Ok(if hash.status.success() && date.status.success() {
+        format!(
+            " ({} {})",
+            str::from_utf8(&hash.stdout)?.trim(),
+            str::from_utf8(&date.stdout)?.trim()
+        )
+    } else {
+        String::new()
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,10 @@ fn main() -> Result<(), anyhow::Error> {
 
 /// A Cargo runner for microcontrollers.
 #[derive(StructOpt)]
-#[structopt(name = "probe-run")]
+#[structopt(
+    name = "probe-run",
+    version = concat!(env!("CARGO_PKG_VERSION"), include_str!(concat!(env!("OUT_DIR"), "/git-info.txt"))),
+)]
 struct Opts {
     /// List supported chips and exit.
     #[structopt(long)]


### PR DESCRIPTION
closes #79 
example:
``` console
$ probe-run --version
probe-run 0.1.3 (f325238 2020-10-23)
```