### PR TITLE
hard-enable the defmt Cargo feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Build host tooling
       run: |
         cargo build
-        cargo build --features defmt
     - name: Build embedded tooling
       working-directory: panic-probe
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "probe-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/probe-run"
+# TODO(on 0.2.0) remove the "defmt" Cargo feature
 version = "0.1.3"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ addr2line = "0.13.0"
 anyhow = "1.0.32"
 arrayref = "0.3.6"
 colored = "2.0.0"
-defmt-decoder = { git = "https://github.com/knurling-rs/defmt", rev = "a6dc090", features = ['unstable'], optional = true }
-defmt-elf2table = { git = "https://github.com/knurling-rs/defmt", rev = "a6dc090", features = ['unstable'], optional = true }
+defmt-decoder = { git = "https://github.com/knurling-rs/defmt", rev = "a6dc090", features = ['unstable'] }
+defmt-elf2table = { git = "https://github.com/knurling-rs/defmt", rev = "a6dc090", features = ['unstable'] }
 gimli = "0.22.0"
 log = { version = "0.4.11", features = ["std"] }
 # an addr2line trait is implement for a type in this particular version
@@ -28,7 +28,8 @@ signal-hook = "0.1.16"
 structopt = "0.3.15"
 
 [features]
-defmt = ["defmt-elf2table", "defmt-decoder"]
+# this feature does nothing and it's kept for backwards compatibility; it will be removed in the next semver bump
+defmt = []
 
 [workspace]
 members = ["panic-probe"]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,4 @@
 use colored::{Color, Colorize};
-#[cfg(feature = "defmt")]
 use defmt_decoder::Frame;
 use io::Write;
 use log::{Level, Log, Metadata, Record};
@@ -21,7 +20,6 @@ pub fn init(verbose: bool) {
 }
 
 /// Logs a defmt frame using the `log` facade.
-#[cfg(feature = "defmt")]
 pub fn log_defmt(
     frame: &Frame<'_>,
     file: Option<&str>,


### PR DESCRIPTION
but keep it around so `cargo install --git $URL --features defmt` continues to work
with this, probe-run will always include defmt support (behind the --defmt command line flag)