### PR TITLE
print supported defmt version from --version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ addr2line = "0.13.0"
 anyhow = "1.0.32"
 arrayref = "0.3.6"
 colored = "2.0.0"
-defmt-decoder = { git = "https://github.com/knurling-rs/defmt", rev = "a6dc090", features = ['unstable'] }
-defmt-elf2table = { git = "https://github.com/knurling-rs/defmt", rev = "a6dc090", features = ['unstable'] }
+defmt-decoder = { git = "https://github.com/knurling-rs/defmt", rev = "3db6b41", features = ['unstable'] }
+defmt-elf2table = { git = "https://github.com/knurling-rs/defmt", rev = "3db6b41", features = ['unstable'] }
 gimli = "0.22.0"
 log = { version = "0.4.11", features = ["std"] }
 # an addr2line trait is implement for a type in this particular version


### PR DESCRIPTION
this helps people identify which defmt version (git or crates.io) they can use with the `probe-run` they currently have installed.

example output (git):
``` console
probe-run 0.1.3 (34019f8 2020-11-11)
supported defmt version: 8ef2c60b7e01a692cb742f0a237ae8ddf1724b9d
```

example output (crates.io): (expected)
``` console
probe-run 0.1.4
supported defmt version: 0.1
```

depends on https://github.com/knurling-rs/defmt/pull/241
TODO: the Cargo.toml needs to be updated after the defmt PR is merged (otherwise this won't pass CI)