### PR TITLE
report program size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -314,7 +314,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
     } else {
         // program lives in Flash
         let size = program_size_of(&elf);
-        log::info!("flashing program ({:.02} KiBi)", size as f64 / 1024 as f64);
+        log::info!("flashing program ({:.02} KiB)", size as f64 / 1024 as f64);
         flashing::download_file(&mut sess, elf_path, Format::Elf)?;
         log::info!("success!");
     }


### PR DESCRIPTION
this reports the size of the part of the program that will loaded to Flash

the count does not include the `.uninit` section (which is marked NOLOAD in cortex-m-rt)

due to a bug in cortex-m-rt (which has already been fixed but the fix is not on crates.io) this will
include `.bss` in the count. the bug also causes probe-rs to load a bunch of zeros, as many as the
size of .bss, to Flash so in a sense the reported value is correct in that it reflects the amount of
work probe-rs will do

fixes #99 

Example output:
``` console
$ cargo run --bin hello
  (HOST) INFO  flashing program (7.64 KiBi)
  (HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
0.000000 INFO  Hello, world!
```