### PR TITLE
colorize defmt::assert_eq output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +127,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -187,6 +196,12 @@ dependencies = [
 name = "defmt-parser"
 version = "0.1.0"
 source = "git+https://github.com/knurling-rs/defmt?rev=1bb6478#1bb6478544a7188b2e7f3ac21939f58f50d56b9f"
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "dtoa"
@@ -542,11 +557,13 @@ name = "probe-run"
 version = "0.1.6"
 dependencies = [
  "addr2line",
+ "ansi_term 0.12.1",
  "anyhow",
  "arrayref",
  "colored",
  "defmt-decoder",
  "defmt-elf2table",
+ "difference",
  "gimli 0.22.0",
  "log",
  "object 0.20.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ version = "0.1.6"
 
 [dependencies]
 addr2line = "0.13.0"
+ansi_term = "0.12.1"
 anyhow = "1.0.32"
 arrayref = "0.3.6"
 colored = "2.0.0"
 defmt-decoder = { git = "https://github.com/knurling-rs/defmt", rev = "1bb6478", version = "0.1.3", features = ['unstable'] }
 defmt-elf2table = { git = "https://github.com/knurling-rs/defmt", rev = "1bb6478", version = "0.1.0", features = ['unstable'] }
+difference = "2.0.0"
 gimli = "0.22.0"
 log = { version = "0.4.11", features = ["std"] }
 # an addr2line trait is implement for a type in this particular version

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -164,6 +164,9 @@ fn color_diff(text: String) -> String {
             && right.starts_with(RIGHT_START)
             && right.ends_with(END)
         {
+            const DARK_RED: Colour = Colour::Fixed(52);
+            const DARK_GREEN: Colour = Colour::Fixed(22);
+
             // `defmt::assert_eq!` output
             let left = &left[LEFT_START.len()..left.len() - END.len()];
             let right = &right[RIGHT_START.len()..right.len() - END.len()];
@@ -189,7 +192,7 @@ fn color_diff(text: String) -> String {
                     }
                     Difference::Add(_) => continue,
                     Difference::Rem(s) => {
-                        write!(buf, "{}", Colour::Red.on(Colour::Fixed(52)).bold().paint(s)).ok();
+                        write!(buf, "{}", Colour::Red.on(DARK_RED).bold().paint(s)).ok();
                     }
                 }
             }
@@ -203,12 +206,7 @@ fn color_diff(text: String) -> String {
                     }
                     Difference::Rem(_) => continue,
                     Difference::Add(s) => {
-                        write!(
-                            buf,
-                            "{}",
-                            Colour::Green.on(Colour::Fixed(22)).bold().paint(s)
-                        )
-                        .ok();
+                        write!(buf, "{}", Colour::Green.on(DARK_GREEN).bold().paint(s)).ok();
                     }
                 }
             }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,8 +1,11 @@
+use ansi_term::Colour;
 use colored::{Color, Colorize};
 use defmt_decoder::Frame;
-use io::Write;
+use difference::{Changeset, Difference};
 use log::{Level, Log, Metadata, Record};
+
 use std::{
+    fmt::Write as _,
     io,
     sync::atomic::{AtomicUsize, Ordering},
 };
@@ -104,7 +107,7 @@ impl Log for Logger {
             .fetch_max(timestamp.len(), Ordering::Relaxed);
 
         let (stdout, stderr, mut stdout_lock, mut stderr_lock);
-        let sink: &mut dyn Write = if is_defmt {
+        let sink: &mut dyn io::Write = if is_defmt {
             // defmt goes to stdout, since it's the primary output produced by this tool.
             stdout = io::stdout();
             stdout_lock = stdout.lock();
@@ -122,7 +125,7 @@ impl Log for Logger {
             self.timing_align.load(Ordering::Relaxed),
             timestamp = timestamp,
             level = record.level().to_string().color(level_color),
-            args = record.args().to_string().bold(),
+            args = color_diff(record.args().to_string()),
         )
         .ok();
 
@@ -141,4 +144,76 @@ impl Log for Logger {
     }
 
     fn flush(&self) {}
+}
+
+// color the output of `defmt::assert_eq`
+// HACK we should not re-parse formatted output but instead directly format into a color diff
+// template; that may require specially tagging log messages that come from `defmt::assert_eq`
+fn color_diff(text: String) -> String {
+    let lines = text.lines().collect::<Vec<_>>();
+    let nlines = lines.len();
+    if nlines > 2 {
+        let left = lines[nlines - 2];
+        let right = lines[nlines - 1];
+
+        const LEFT_START: &str = " left: `";
+        const RIGHT_START: &str = "right: `";
+        const END: &str = "`";
+        if left.starts_with(LEFT_START)
+            && left.ends_with(END)
+            && right.starts_with(RIGHT_START)
+            && right.ends_with(END)
+        {
+            let left = &left[LEFT_START.len()..left.len() - END.len()];
+            let right = &right[RIGHT_START.len()..right.len() - END.len()];
+
+            let mut buf = lines[..nlines - 2].join("\n").bold().to_string();
+            buf.push('\n');
+
+            let changeset = Changeset::new(left, right, "");
+
+            writeln!(
+                buf,
+                "{} {} / {}",
+                "diff".bold(),
+                "< left".red(),
+                "right >".green()
+            )
+            .ok();
+            write!(buf, "{}", "<".red()).ok();
+            for diff in &changeset.diffs {
+                match diff {
+                    Difference::Same(s) => {
+                        write!(buf, "{}", s.red()).ok();
+                    }
+                    Difference::Add(_) => continue,
+                    Difference::Rem(s) => {
+                        write!(buf, "{}", Colour::Red.on(Colour::Fixed(52)).bold().paint(s)).ok();
+                    }
+                }
+            }
+            buf.push('\n');
+
+            write!(buf, "{}", ">".green()).ok();
+            for diff in &changeset.diffs {
+                match diff {
+                    Difference::Same(s) => {
+                        write!(buf, "{}", s.green()).ok();
+                    }
+                    Difference::Rem(_) => continue,
+                    Difference::Add(s) => {
+                        write!(
+                            buf,
+                            "{}",
+                            Colour::Green.on(Colour::Fixed(22)).bold().paint(s)
+                        )
+                        .ok();
+                    }
+                }
+            }
+            return buf;
+        }
+    }
+
+    text.bold().to_string()
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -164,6 +164,7 @@ fn color_diff(text: String) -> String {
             && right.starts_with(RIGHT_START)
             && right.ends_with(END)
         {
+            // `defmt::assert_eq!` output
             let left = &left[LEFT_START.len()..left.len() - END.len()];
             let right = &right[RIGHT_START.len()..right.len() - END.len()];
 
@@ -215,5 +216,6 @@ fn color_diff(text: String) -> String {
         }
     }
 
+    // keep output as it is
     text.bold().to_string()
 }


### PR DESCRIPTION
this implementation parses a formatted log message and checks if the output corresponds to the `defmt::assert_eq!` macro. If that's the case then it applies color using the same approach as the `pretty-assertions` crate.

a better implementation would be to tag the log messages from the `defmt::assert_eq` and apply the coloring based on the tag, instead of re-parsing the formatted log message. however, that doesn't seem possible to implement in the v0.1.x line because:
- if we add a new variant to `decoder::Tag` that would be a breaking change (UB?) because the enum is not `repr(C)`
- if we try to apply to formatting when the `SymbolTag::Custom` tag is present then old versiosn of probe-run will not print the `assert_eq` message (as they ignore custom tags)