### PR TITLE
Wait for breakpoint to actually hit before switching RTT to blocking.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
         if let Some(rtt) = rtt_addr {
             core.set_hw_breakpoint(main)?;
             core.run()?;
+            core.wait_for_core_halted(Duration::from_secs(5))?;
             const OFFSET: u32 = 44;
             const FLAG: u32 = 2; // BLOCK_IF_FULL
             core.write_word_32(rtt + OFFSET, FLAG)?;


### PR DESCRIPTION
Without this I was seeing my firmware boot without RTT being changed to blocking mode. 

I guess probe-run would change mode before the RTT control block is actually initialized, so it'd get overwritten.