### PR TITLE
Print probe list when multiple probes were found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
     logger::init(opts.verbose);
 
     if opts.list_probes {
-        return print_probes();
+        return print_probes(Probe::list_all());
     }
 
     if opts.list_chips {
@@ -301,6 +301,7 @@ fn notmain() -> Result<i32, anyhow::Error> {
     }
     log::debug!("found {} probes", probes.len());
     if probes.len() > 1 {
+        let _ = print_probes(probes);
         bail!("more than one probe found; use --probe to specify which one to use");
     }
     let mut probe = probes[0].open()?;
@@ -852,9 +853,7 @@ fn probes_filter(probes: &[DebugProbeInfo], selector: &DebugProbeSelector) -> Ve
         .collect()
 }
 
-fn print_probes() -> Result<i32, anyhow::Error> {
-    let probes = Probe::list_all();
-
+fn print_probes(probes: Vec<DebugProbeInfo>) -> Result<i32, anyhow::Error> {
     if !probes.is_empty() {
         println!("The following devices were found:");
         probes


### PR DESCRIPTION
Prints all discovered probes when error is multiple probes found. Adapts
print_probes to accept a Vec such that it does not list probes after
they were already listed previously.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #118 