### PR TITLE
reject use of defmt and --no-flash (again)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -385,9 +385,6 @@ fn notmain() -> Result<i32, anyhow::Error> {
         core.run()?;
     }
 
-    // Print a separator before the device messages start.
-    eprintln!("{}", "─".repeat(80).dimmed());
-
     let exit = Arc::new(AtomicBool::new(false));
     let sig_id = signal_hook::flag::register(signal_hook::SIGINT, exit.clone())?;
 
@@ -399,6 +396,10 @@ fn notmain() -> Result<i32, anyhow::Error> {
         .as_ref()
         .map_or(false, |ch| ch.name() == Some("defmt"));
 
+    if use_defmt && opts.no_flash {
+        bail!("\"defmt\" RTT channel is in use, but `--no-flash` was specified -- this combination is not allowed");
+    }
+
     if use_defmt && table.is_none() {
         bail!("\"defmt\" RTT channel is in use, but the firmware binary contains no defmt data");
     }
@@ -406,6 +407,9 @@ fn notmain() -> Result<i32, anyhow::Error> {
     if !use_defmt {
         table = None;
     }
+
+    // Print a separator before the device messages start.
+    eprintln!("{}", "─".repeat(80).dimmed());
 
     // wait for breakpoint
     let stdout = io::stdout();

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,7 +397,9 @@ fn notmain() -> Result<i32, anyhow::Error> {
         .map_or(false, |ch| ch.name() == Some("defmt"));
 
     if use_defmt && opts.no_flash {
-        bail!("\"defmt\" RTT channel is in use, but `--no-flash` was specified -- this combination is not allowed");
+        bail!(
+            "attempted to use `--no-flash` and `defmt` logging -- this combination is not allowed. Remove the `--no-flash` flag"
+        );
     }
 
     if use_defmt && table.is_none() {


### PR DESCRIPTION
before PR #105 using defmt required the `--defmt` flag. At that time it was not possible to use the `--defmt` and `--no-flash` flags together. The rationale for that restriction is that without it `cargo run` can invoke `probe-run` with a newer version of the ELF different from the ELF that was last flashed on the device and that can result in log messages that make no sense and/or decoder errors.

After PR 105 landed it unintentionally became possible to use defmt with --no-flash due to the auto-detection (auto-enable) mechanism. This PR corrects that and makes the use of `--no-flash` flag and defmt an error again.