### PR TITLE
bump version in Cargo.toml and -.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "probe-run"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "addr2line",
  "ansi_term 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "probe-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/probe-run"
 # TODO(on 0.2.0) remove the "defmt" Cargo feature
-version = "0.1.8"
+version = "0.1.9"
 
 [dependencies]
 addr2line = "0.13.0"


### PR DESCRIPTION
just wanted to make extra sure I don't break anything; self-assigning because trivial