### PR TITLE
remind the user that the `bench` profile should be also overridden

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -807,7 +807,7 @@ fn backtrace(
 
         let uwt_row = debug_frame.unwind_info_for_address(bases, ctx, pc.into(), DebugFrame::cie_from_offset).with_context(|| {
             "debug information is missing. Likely fixes:
-1. compile the Rust code with `debug = 1` or higher. This is configured in the `profile.*` section of Cargo.toml
+1. compile the Rust code with `debug = 1` or higher. This is configured in the `profile.{release,bench}` sections of Cargo.toml (`profile.{dev,test}` default to `debug = 2`)
 2. use a recent version of the `cortex-m` crates (e.g. cortex-m 0.6.3 or newer). Check versions in Cargo.lock
 3. if linking to C code, compile the C code with the `-g` flag"
         })?;


### PR DESCRIPTION
with `debug = 1` to avoid running into #9