### PR TITLE
Skip defmt version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ If they are exposed, you can connect a "stand alone" probe device to the microco
 
 Note that this may involve some soldering if your board does not come with a pre-attached header to plug your debugger into.
 
+### defmt version mismatch
+
+#### end-user
+Follow the instructions in the error message to resolve the mismatch.
+
+#### developer
+If you are building `probe-run` from source, you can disable the version check by setting the `PROBE_RUN_IGNORE_VERSION` environment variable to `true` or `1` at compile time.
+
 ## Support Us
 
 `probe-run` is part of the [Knurling] project, [Ferrous Systems]' effort at

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,27 +180,23 @@ fn notmain() -> anyhow::Result<i32> {
             )
         })?;
 
-    let (mut table, locs) = {
-        let table = defmt_decoder::Table::parse(&bytes)?;
+    // Parse defmt_decoder-table from bytes
+    // * skip defmt version check, if `PROBE_RUN_IGNORE_VERSION` matches one of the options
+    let mut table = defmt_decoder::Table::parse(&bytes)?;
+    // Extract the `Locations` from the table, if there is a table
+    let mut locs = None;
+    if let Some(table) = table.as_ref() {
+        let tmp = table.get_locations(&bytes)?;
 
-        let locs = if let Some(table) = table.as_ref() {
-            let locs = table.get_locations(&bytes)?;
-
-            if !table.is_empty() && locs.is_empty() {
-                log::warn!("insufficient DWARF info; compile your program with `debug = 2` to enable location info");
-                None
-            } else if table.indices().all(|idx| locs.contains_key(&(idx as u64))) {
-                Some(locs)
-            } else {
-                log::warn!("(BUG) location info is incomplete; it will be omitted from the output");
-                None
-            }
+        if !table.is_empty() && tmp.is_empty() {
+            log::warn!("insufficient DWARF info; compile your program with `debug = 2` to enable location info");
+        } else if table.indices().all(|idx| tmp.contains_key(&(idx as u64))) {
+            locs = Some(tmp);
         } else {
-            None
-        };
-
-        (table, locs)
-    };
+            log::warn!("(BUG) location info is incomplete; it will be omitted from the output");
+        }
+    }
+    let locs = locs;
 
     // sections used in cortex-m-rt
     // NOTE we won't load `.uninit` so it is not included here

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,10 @@ fn notmain() -> anyhow::Result<i32> {
 
     // Parse defmt_decoder-table from bytes
     // * skip defmt version check, if `PROBE_RUN_IGNORE_VERSION` matches one of the options
-    let mut table = defmt_decoder::Table::parse(&bytes)?;
+    let mut table = match option_env!("PROBE_RUN_IGNORE_VERSION") {
+        Some("true") | Some("1") => defmt_decoder::Table::parse_ignore_version(&bytes)?,
+        _ => defmt_decoder::Table::parse(&bytes)?,
+    };
     // Extract the `Locations` from the table, if there is a table
     let mut locs = None;
     if let Some(table) = table.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,7 @@ fn notmain() -> anyhow::Result<i32> {
             ram.range.end - 1
         );
     }
+    let ram_region = ram_region;
 
     // NOTE we want to raise the linking error before calling `defmt_decoder::Table::parse`
     let text = elf
@@ -264,6 +265,7 @@ fn notmain() -> anyhow::Result<i32> {
             }
         }
     }
+    let (debug_frame, vector_table) = (debug_frame, vector_table);
 
     let live_functions = elf
         .symbols()
@@ -395,6 +397,7 @@ fn notmain() -> anyhow::Result<i32> {
         core.set_hw_breakpoint(vector_table.hard_fault & !THUMB_BIT)?;
         core.run()?;
     }
+    let canary = canary;
 
     // Register a signal handler that sets `exit` to `true` on Ctrl+C. On the second Ctrl+C, the
     // signal's default action will be run.


### PR DESCRIPTION
workaround for #172 

I started out using `fn std::env::var(...)`, which inspects the env var at runtime, but thought that it makes more sense to check it during compile time using `option_env!`, because this prevents end users from using this and not actually fixing the mismatch.

While on it I added some refactoring. 🙂 