### PR TITLE
limit backtrace length, make limit configurable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -797,10 +797,12 @@ fn construct_backtrace(
         // Link Register contains an EXC_RETURN value. This deliberately also includes
         // invalid combinations of final bits 0-4 to prevent futile backtrace re-generation attempts
         let exception_entry = lr >= EXC_RETURN_MARKER;
+
+        // Since we strip the thumb bit from `pc`, ignore it in this comparison.
+        let program_counter_changed = (lr & !THUMB_BIT) != (pc & !THUMB_BIT);
         // If the frame didn't move, and the program counter didn't change, bail out (otherwise we
         // might print the same frame over and over).
-        // Since we strip the thumb bit from `pc`, ignore it in this comparison.
-        let stack_corrupted = !cfa_changed && lr & !THUMB_BIT == pc & !THUMB_BIT;
+        let stack_corrupted = !cfa_changed && !program_counter_changed;
 
         if !print_backtrace && (stack_corrupted || exception_entry) {
             // we haven't printed a backtrace yet but have discovered a corrupted stack or exception:

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,10 @@ struct Opts {
     #[structopt(long)]
     force_backtrace: bool,
 
+    /// Configure the number of lines to print before a backtrace gets cut off
+    #[structopt(long, default_value = "50")]
+    max_backtrace_len: u32,
+
     /// Arguments passed after the ELF file path are discarded
     #[structopt(name = "REST")]
     _rest: Vec<String>,
@@ -143,6 +147,7 @@ fn notmain() -> anyhow::Result<i32> {
     }
 
     let force_backtrace = opts.force_backtrace;
+    let max_backtrace_len = opts.max_backtrace_len;
     let elf_path = opts.elf.as_deref().unwrap();
     let chip = opts.chip.as_deref().unwrap();
     let bytes = fs::read(elf_path)?;
@@ -559,6 +564,7 @@ fn notmain() -> anyhow::Result<i32> {
         &current_dir,
         // TODO any other cases in which we should force a backtrace?
         force_backtrace || canary_touched,
+        max_backtrace_len,
     )?;
 
     core.reset_and_halt(TIMEOUT)?;
@@ -644,6 +650,7 @@ fn construct_backtrace(
     live_functions: &HashSet<&str>,
     current_dir: &Path,
     force_backtrace: bool,
+    max_backtrace_len: u32,
 ) -> Result<Option<TopException>, anyhow::Error> {
     let mut debug_frame = DebugFrame::new(debug_frame, LittleEndian);
     // 32-bit ARM -- this defaults to the host's address size which is likely going to be 8
@@ -848,6 +855,15 @@ fn construct_backtrace(
                 bail!("bug? LR ({:#010x}) didn't have the Thumb bit set", lr)
             }
             pc = lr & !THUMB_BIT;
+        }
+
+        if frame_index >= max_backtrace_len {
+            log::warn!(
+                "maximum backtrace length of {} reached; cutting off the rest
+               note: re-run with `--max-backtrace-len=<your maximum>` to extend this limit",
+                max_backtrace_len
+            );
+            return Ok(top_exception);
         }
     }
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -34,6 +34,10 @@ impl<'c, 'probe> Registers<'c, 'probe> {
         self.cache.insert(reg.0, val);
     }
 
+    /// Updates the Canonical Frame Address (CFA), e.g.
+    /// the value of the Stack Pointer (SP) on function entry – the current frame we're looking at
+    ///
+    /// returns `true` if the CFA has changed
     pub fn update_cfa(
         &mut self,
         rule: &CfaRule<EndianSlice<LittleEndian>>,


### PR DESCRIPTION
mitigation for https://github.com/knurling-rs/probe-run/issues/127

example run with user-configured limit:
```console
➜  probe-run git:(127-fix-infinte-loop) ✗ cr -- --max-backtrace-len=3 --chip nRF52840_xxAA  rtc_async.elf
   Compiling probe-run v0.2.1 (/Users/lottesteenbrink/ferrous/knurling/probe-run)
    Finished dev [unoptimized + debuginfo] target(s) in 6.64s
     Running `target/debug/probe-run --max-backtrace-len=3 --chip nRF52840_xxAA rtc_async.elf`
  (HOST) INFO  flashing program (11.52 KiB)
  (HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
       0 INFO  Hello World!
└─ rtc_async::__cortex_m_rt_main @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:42
       1 INFO  tick
└─ rtc_async::run2::task::{{closure}} @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:31
       2 INFO  BIG INFREQUENT TICK
└─ rtc_async::run1::task::{{closure}} @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:22
       3 INFO  tick
└─ rtc_async::run2::task::{{closure}} @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:31
       4 INFO  tick
└─ rtc_async::run2::task::{{closure}} @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:31
       5 INFO  tick
└─ rtc_async::run2::task::{{closure}} @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:31
       6 INFO  tick
└─ rtc_async::run2::task::{{closure}} @ /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:31
────────────────────────────────────────────────────────────────────────────────
stack backtrace:
   0: HardFaultTrampoline
      <exception entry>
   1: rtc_async::run1::task::{{closure}}
        at /home/dirbaio/akiles/embassy/embassy-nrf-examples/src/bin/rtc_async.rs:24
   2: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
        at /home/dirbaio/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80
   3: embassy::executor::Task<F>::poll
        at /home/dirbaio/akiles/embassy/embassy/src/executor/mod.rs:71
  (HOST) WARN  Maximum backtrace length of 3 reached; cutting off the rest
               note: re-run with `--max-backtrace-len=<your maximum>` to extend this limit
  (HOST) ERROR the program panicked
```