### PR TITLE
refactor "print backtrace" code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "enum-primitive-derive"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +527,7 @@ dependencies = [
  "colored",
  "defmt-decoder",
  "difference",
+ "either",
  "gimli",
  "hidapi",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ arrayref = "0.3.6"
 colored = "2.0.0"
 defmt-decoder = { git = "https://github.com/knurling-rs/defmt", tag = "defmt-decoder-v0.2.0", version = "=0.2.0", features = ['unstable'] }
 difference = "2.0.0"
+either = "1.6.1"
 gimli = "0.23.0"
 log = "0.4.14"
 # an addr2line trait is implement for a type in this particular version

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -9,8 +9,13 @@ mod pp;
 mod symbolicate;
 mod unwind;
 
+pub(crate) struct Settings<'p> {
+    pub(crate) current_dir: &'p Path,
+    pub(crate) max_backtrace_len: u32,
+    pub(crate) force_backtrace: bool,
+}
+
 /// (virtually) unwinds the target's program and prints its backtrace
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn print(
     core: &mut Core,
     debug_frame: &[u8],
@@ -18,26 +23,29 @@ pub(crate) fn print(
     vector_table: &VectorTable,
     sp_ram_region: &Option<RamRegion>,
     live_functions: &HashSet<&str>,
-    current_dir: &Path,
-    force_backtrace: bool,
-    max_backtrace_len: u32,
+    settings: &Settings,
 ) -> anyhow::Result<Outcome> {
     let unwind = unwind::target(core, debug_frame, vector_table, sp_ram_region)?;
 
-    let frames = symbolicate::frames(&unwind.raw_frames, live_functions, current_dir, elf);
+    let frames = symbolicate::frames(
+        &unwind.raw_frames,
+        live_functions,
+        settings.current_dir,
+        elf,
+    );
 
     let contains_exception = unwind
         .raw_frames
         .iter()
         .any(|raw_frame| raw_frame.is_exception());
 
-    let print_backtrace = force_backtrace
+    let print_backtrace = settings.force_backtrace
         || unwind.outcome == Outcome::StackOverflow
         || unwind.corrupted
         || contains_exception;
 
-    if print_backtrace && max_backtrace_len > 0 {
-        pp::backtrace(&frames, max_backtrace_len);
+    if print_backtrace && settings.max_backtrace_len > 0 {
+        pp::backtrace(&frames, settings.max_backtrace_len);
 
         if unwind.corrupted {
             log::warn!("call stack was corrupted; unwinding could not be completed");

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,0 +1,48 @@
+use std::{collections::HashSet, path::Path};
+
+use object::read::File as ElfFile;
+use probe_rs::{config::RamRegion, Core};
+
+use crate::{Outcome, VectorTable};
+
+mod pp;
+mod symbolicate;
+mod unwind;
+
+/// (virtually) unwinds the target's program and prints its backtrace
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn print(
+    core: &mut Core,
+    debug_frame: &[u8],
+    elf: &ElfFile,
+    vector_table: &VectorTable,
+    sp_ram_region: &Option<RamRegion>,
+    live_functions: &HashSet<&str>,
+    current_dir: &Path,
+    force_backtrace: bool,
+    max_backtrace_len: u32,
+) -> anyhow::Result<Outcome> {
+    let unwind = unwind::target(core, debug_frame, vector_table, sp_ram_region)?;
+
+    let frames = symbolicate::frames(&unwind.raw_frames, live_functions, current_dir, elf);
+
+    let contains_exception = unwind
+        .raw_frames
+        .iter()
+        .any(|raw_frame| raw_frame.is_exception());
+
+    let print_backtrace = force_backtrace
+        || unwind.outcome == Outcome::StackOverflow
+        || unwind.corrupted
+        || contains_exception;
+
+    if print_backtrace && max_backtrace_len > 0 {
+        pp::backtrace(&frames, max_backtrace_len);
+
+        if unwind.corrupted {
+            log::warn!("call stack was corrupted; unwinding could not be completed");
+        }
+    }
+
+    Ok(unwind.outcome)
+}

--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -32,13 +32,11 @@ pub(crate) fn backtrace(frames: &[Frame], max_backtrace_len: u32) {
                 frame_index += 1;
 
                 if frame_index >= max_backtrace_len {
-                    // NOTE whitespace preceding "note: " is intentional and used for alignment
-                    // purposes
                     log::warn!(
-                        "maximum backtrace length of {} reached; cutting off the rest.
-               note: re-run with `--max-backtrace-len=<your maximum>` to extend this limit",
+                        "maximum backtrace length of {} reached; cutting off the rest.const ",
                         max_backtrace_len
                     );
+                    log::warn!("note: re-run with `--max-backtrace-len=<your maximum>` to extend this limit");
 
                     break;
                 }

--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -1,0 +1,48 @@
+//! Pretty printing the backtrace
+
+use std::borrow::Cow;
+
+use colored::Colorize as _;
+
+use super::symbolicate::Frame;
+
+/// Pretty prints processed backtrace frames up to `max_backtrace_len`
+pub(crate) fn backtrace(frames: &[Frame], max_backtrace_len: u32) {
+    println!("{}", "stack backtrace:".dimmed());
+
+    let mut frame_index = 0;
+    for frame in frames {
+        match frame {
+            Frame::Exception => {
+                println!("      <exception entry>");
+            }
+
+            Frame::Subroutine(subroutine) => {
+                let name = match &subroutine.name_or_pc {
+                    either::Either::Left(name) => Cow::Borrowed(name),
+                    either::Either::Right(pc) => Cow::Owned(format!("??? (PC={:#010x})", pc)),
+                };
+
+                println!("{:>4}: {}", frame_index, name);
+
+                if let Some(location) = &subroutine.location {
+                    println!("        at {}:{}", location.path.display(), location.line);
+                }
+
+                frame_index += 1;
+
+                if frame_index >= max_backtrace_len {
+                    // NOTE whitespace preceding "note: " is intentional and used for alignment
+                    // purposes
+                    log::warn!(
+                        "maximum backtrace length of {} reached; cutting off the rest.
+               note: re-run with `--max-backtrace-len=<your maximum>` to extend this limit",
+                        max_backtrace_len
+                    );
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/backtrace/symbolicate.rs
+++ b/src/backtrace/symbolicate.rs
@@ -1,0 +1,174 @@
+//! Turns PC addresses into function names and locations
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use addr2line::fallible_iterator::FallibleIterator as _;
+use either::Either;
+use gimli::{EndianReader, RunTimeEndian};
+use object::{read::File as ElfFile, Object as _, SymbolMap, SymbolMapName};
+
+use crate::cortexm;
+
+use super::unwind::RawFrame;
+
+pub(crate) fn frames(
+    raw_frames: &[RawFrame],
+    live_functions: &HashSet<&str>,
+    current_dir: &Path,
+    elf: &ElfFile,
+) -> Vec<Frame> {
+    let mut frames = vec![];
+
+    let symtab = elf.symbol_map();
+    let addr2line = addr2line::Context::new(elf).ok();
+
+    for raw_frame in raw_frames {
+        match raw_frame {
+            RawFrame::Exception => frames.push(Frame::Exception),
+
+            RawFrame::Subroutine { pc } => {
+                for subroutine in Subroutine::from_pc(
+                    *pc,
+                    addr2line.as_ref(),
+                    live_functions,
+                    current_dir,
+                    &symtab,
+                ) {
+                    frames.push(Frame::Subroutine(subroutine))
+                }
+            }
+        }
+    }
+
+    frames
+}
+
+/// Processed frame
+#[derive(Debug)]
+pub(crate) enum Frame {
+    Exception,
+    Subroutine(Subroutine),
+}
+
+/// "Symbolicated" and de-inlined subroutine frame
+#[derive(Debug)]
+pub(crate) struct Subroutine {
+    pub(crate) name_or_pc: Either<String, u32>,
+    pub(crate) location: Option<Location>,
+}
+
+type A2lContext = addr2line::Context<EndianReader<RunTimeEndian, Rc<[u8]>>>;
+
+impl Subroutine {
+    fn from_pc(
+        pc: u32,
+        addr2line: Option<&A2lContext>,
+        live_functions: &HashSet<&str>,
+        current_dir: &Path,
+        symtab: &SymbolMap<SymbolMapName>,
+    ) -> Vec<Subroutine> {
+        addr2line
+            .and_then(|addr2line| {
+                Self::from_debuginfo(pc, addr2line, live_functions, current_dir, symtab)
+            })
+            .unwrap_or_else(|| vec![Self::from_symtab(pc, symtab)])
+    }
+
+    fn from_debuginfo(
+        pc: u32,
+        addr2line: &A2lContext,
+        live_functions: &HashSet<&str>,
+        current_dir: &Path,
+        symtab: &SymbolMap<SymbolMapName>,
+    ) -> Option<Vec<Subroutine>> {
+        let frames: Vec<_> = addr2line.find_frames(pc as u64).ok()?.collect().ok()?;
+
+        let top_subroutine = frames.last();
+
+        let has_valid_debuginfo = if let Some(function) =
+            top_subroutine.and_then(|subroutine| subroutine.function.as_ref())
+        {
+            live_functions.contains(&*function.raw_name().ok()?)
+        } else {
+            false
+        };
+
+        if !has_valid_debuginfo {
+            return None;
+        }
+
+        let mut subroutines = vec![];
+
+        for frame in &frames {
+            let demangled_name = frame
+                .function
+                .as_ref()
+                .and_then(|function| function.demangle().ok())
+                .map(|cow| cow.into_owned());
+
+            // XXX if there was inlining AND there's no function name info we'll report several
+            // frames with the same PC
+            let name_or_pc = demangled_name
+                .map(Either::Left)
+                .unwrap_or_else(|| name_from_symtab(pc, symtab));
+
+            let location = if let Some((file, line)) = frame
+                .location
+                .as_ref()
+                .and_then(|loc| loc.file.and_then(|file| loc.line.map(|line| (file, line))))
+            {
+                let fullpath = Path::new(file);
+                let path = if let Ok(relpath) = fullpath.strip_prefix(&current_dir) {
+                    relpath
+                } else {
+                    fullpath
+                };
+
+                Some(Location {
+                    line,
+                    path: path.to_owned(),
+                })
+            } else {
+                None
+            };
+
+            subroutines.push(Subroutine {
+                name_or_pc,
+                location,
+            })
+        }
+
+        Some(subroutines)
+    }
+
+    fn from_symtab(pc: u32, symtab: &SymbolMap<SymbolMapName>) -> Subroutine {
+        Subroutine {
+            name_or_pc: name_from_symtab(pc, symtab),
+            location: None,
+        }
+    }
+}
+
+fn name_from_symtab(pc: u32, symtab: &SymbolMap<SymbolMapName>) -> Either<String, u32> {
+    // the .symtab appears to use address ranges that have their thumb bits set (e.g.
+    // `0x101..0x200`). Passing the `pc` with the thumb bit cleared (e.g. `0x100`) to the
+    // lookup function sometimes returns the *previous* symbol. Work around the issue by
+    // setting `pc`'s thumb bit before looking it up
+    let address = cortexm::set_thumb_bit(pc) as u64;
+
+    symtab
+        .get(address)
+        .map(|symbol| symbol.name().to_owned())
+        .map(Either::Left)
+        .unwrap_or(Either::Right(pc))
+}
+
+#[derive(Debug)]
+pub(crate) struct Location {
+    pub(crate) line: u32,
+    pub(crate) path: PathBuf,
+}

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -1,0 +1,174 @@
+//! unwind target's program
+
+use anyhow::{bail, ensure, Context as _};
+use gimli::{
+    BaseAddresses, DebugFrame, LittleEndian, UninitializedUnwindContext, UnwindSection as _,
+};
+use probe_rs::{config::RamRegion, Core};
+
+use crate::{
+    cortexm,
+    registers::{self, Registers},
+    stacked::Stacked,
+    Outcome, VectorTable,
+};
+
+static MISSING_DEBUG_INFO: &str = "debug information is missing. Likely fixes:
+1. compile the Rust code with `debug = 1` or higher. This is configured in the `profile.{release,bench}` sections of Cargo.toml (`profile.{dev,test}` default to `debug = 2`)
+2. use a recent version of the `cortex-m` crates (e.g. cortex-m 0.6.3 or newer). Check versions in Cargo.lock
+3. if linking to C code, compile the C code with the `-g` flag";
+
+/// Virtually* unwinds the target's program
+/// \* destructors are not run
+// FIXME(?) this should be "infallible" and return as many frames as possible even in case of IO
+// errors
+pub(crate) fn target(
+    core: &mut Core,
+    debug_frame: &[u8],
+    vector_table: &VectorTable,
+    sp_ram_region: &Option<RamRegion>,
+) -> anyhow::Result<Output> {
+    let mut debug_frame = DebugFrame::new(debug_frame, LittleEndian);
+    debug_frame.set_address_size(cortexm::ADDRESS_SIZE);
+
+    let mut pc = core.read_core_reg(registers::PC)?;
+    let sp = core.read_core_reg(registers::SP)?;
+    let lr = core.read_core_reg(registers::LR)?;
+    let base_addresses = BaseAddresses::default();
+    let mut unwind_context = UninitializedUnwindContext::new();
+
+    let mut outcome = Outcome::Ok;
+    let mut registers = Registers::new(lr, sp, core);
+    let mut raw_frames = vec![];
+    let mut corrupted = true;
+
+    loop {
+        if cortexm::is_hard_fault(pc, vector_table) {
+            debug_assert!(
+                raw_frames.is_empty(),
+                "when present HardFault handler must be the first frame we unwind but wasn't"
+            );
+
+            outcome = if overflowed_stack(sp, sp_ram_region) {
+                Outcome::StackOverflow
+            } else {
+                Outcome::HardFault
+            };
+        }
+
+        raw_frames.push(RawFrame::Subroutine { pc });
+
+        let uwt_row = debug_frame
+            .unwind_info_for_address(
+                &base_addresses,
+                &mut unwind_context,
+                pc.into(),
+                DebugFrame::cie_from_offset,
+            )
+            .with_context(|| MISSING_DEBUG_INFO)?;
+
+        let cfa_changed = registers.update_cfa(uwt_row.cfa())?;
+
+        for (reg, rule) in uwt_row.registers() {
+            registers.update(reg, rule)?;
+        }
+
+        let lr = registers.get(registers::LR)?;
+
+        log::debug!("LR={:#010X} PC={:#010X}", lr, pc);
+
+        if lr == registers::LR_END {
+            break;
+        }
+
+        // Link Register contains an EXC_RETURN value. This deliberately also includes
+        // invalid combinations of final bits 0-4 to prevent futile backtrace re-generation attempts
+        let exception_entry = lr >= cortexm::EXC_RETURN_MARKER;
+
+        let program_counter_changed = !cortexm::subroutine_eq(lr, pc);
+
+        // If the frame didn't move, and the program counter didn't change, bail out (otherwise we
+        // might print the same frame over and over).
+        corrupted = !cfa_changed && !program_counter_changed;
+
+        if corrupted {
+            break;
+        }
+
+        if exception_entry {
+            raw_frames.push(RawFrame::Exception);
+
+            let fpu = match lr {
+                0xFFFFFFF1 | 0xFFFFFFF9 | 0xFFFFFFFD => false,
+                0xFFFFFFE1 | 0xFFFFFFE9 | 0xFFFFFFED => true,
+                _ => bail!("LR contains invalid EXC_RETURN value {:#010X}", lr),
+            };
+
+            let sp = registers.get(registers::SP)?;
+            let ram_bounds = sp_ram_region
+                .as_ref()
+                .map(|ram_region| ram_region.range.clone())
+                .unwrap_or(cortexm::VALID_RAM_ADDRESS);
+            let stacked = if let Some(stacked) = Stacked::read(registers.core, sp, fpu, ram_bounds)?
+            {
+                stacked
+            } else {
+                corrupted = true;
+                break;
+            };
+
+            registers.insert(registers::LR, stacked.lr);
+            // adjust the stack pointer for stacked registers
+            registers.insert(registers::SP, sp + stacked.size());
+
+            pc = stacked.pc;
+        } else {
+            ensure!(
+                cortexm::is_thumb_bit_set(lr),
+                "bug? LR ({:#010x}) didn't have the Thumb bit set",
+                lr
+            );
+
+            pc = cortexm::clear_thumb_bit(lr);
+        }
+    }
+
+    Ok(Output {
+        corrupted,
+        outcome,
+        raw_frames,
+    })
+}
+
+#[derive(Debug)]
+pub struct Output {
+    pub(crate) corrupted: bool,
+    pub(crate) outcome: Outcome,
+    pub(crate) raw_frames: Vec<RawFrame>,
+}
+
+/// Backtrace frame prior to 'symbolication'
+#[derive(Debug)]
+pub(crate) enum RawFrame {
+    Subroutine { pc: u32 },
+    Exception,
+}
+
+impl RawFrame {
+    /// Returns `true` if the raw_frame is [`Exception`].
+    pub(crate) fn is_exception(&self) -> bool {
+        matches!(self, Self::Exception)
+    }
+}
+
+fn overflowed_stack(sp: u32, sp_ram_region: &Option<RamRegion>) -> bool {
+    if let Some(sp_ram_region) = sp_ram_region {
+        // NOTE stack is full descending; meaning the stack pointer can be
+        // `ORIGIN(RAM) + LENGTH(RAM)`
+        let range = sp_ram_region.range.start..=sp_ram_region.range.end;
+        !range.contains(&sp)
+    } else {
+        log::warn!("no RAM region appears to contain the stack; cannot determine if this was a stack overflow");
+        false
+    }
+}

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -44,7 +44,7 @@ pub(crate) fn target(
 
     loop {
         if cortexm::is_hard_fault(pc, vector_table) {
-            debug_assert!(
+            assert!(
                 raw_frames.is_empty(),
                 "when present HardFault handler must be the first frame we unwind but wasn't"
             );

--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -1,0 +1,35 @@
+//! ARM Cortex-M specific constants
+
+use std::{mem, ops::Range};
+
+use crate::VectorTable;
+
+pub(crate) const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
+pub(crate) const EXC_RETURN_MARKER: u32 = 0xFFFF_FFF0;
+const THUMB_BIT: u32 = 1;
+// According to the ARM Cortex-M Reference Manual RAM memory must be located in this address range
+// (vendors still place e.g. Core-Coupled RAM outside this address range)
+pub(crate) const VALID_RAM_ADDRESS: Range<u32> = 0x2000_0000..0x4000_0000;
+
+pub(crate) fn clear_thumb_bit(addr: u32) -> u32 {
+    addr & !THUMB_BIT
+}
+
+/// Checks if PC is the HardFault handler
+// XXX may want to relax this to cover the whole PC range of the `HardFault` handler
+pub(crate) fn is_hard_fault(pc: u32, vector_table: &VectorTable) -> bool {
+    subroutine_eq(pc, vector_table.hard_fault)
+}
+
+pub(crate) fn is_thumb_bit_set(addr: u32) -> bool {
+    addr & THUMB_BIT == THUMB_BIT
+}
+
+pub(crate) fn set_thumb_bit(addr: u32) -> u32 {
+    addr | THUMB_BIT
+}
+
+/// Checks if two subroutine addresses are equivalent by first clearing their `THUMB_BIT`
+pub(crate) fn subroutine_eq(addr1: u32, addr2: u32) -> bool {
+    addr1 & !THUMB_BIT == addr2 & !THUMB_BIT
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -539,6 +539,13 @@ fn notmain() -> anyhow::Result<i32> {
 
     print_separator();
 
+    let backtrace_settings = backtrace::Settings {
+        current_dir: &current_dir,
+        max_backtrace_len,
+        // TODO any other cases in which we should force a backtrace?
+        force_backtrace: force_backtrace || canary_touched,
+    };
+
     let outcome = backtrace::print(
         &mut core,
         debug_frame,
@@ -546,10 +553,7 @@ fn notmain() -> anyhow::Result<i32> {
         &vector_table,
         &sp_ram_region,
         &live_functions,
-        &current_dir,
-        // TODO any other cases in which we should force a backtrace?
-        force_backtrace || canary_touched,
-        max_backtrace_len,
+        &backtrace_settings,
     )?;
 
     core.reset_and_halt(TIMEOUT)?;


### PR DESCRIPTION
this commit refactors the code that prints the backtrace to be comprised of 3 smaller steps

- `unwind::target`, talks to the probe and unwinds the target's program retrieving only a series of PC (program counters). This is fallible due to potential IO errors
- `symbolicate::frames`, turns those raw PC values into function names and locations; it also expands inlined functions. This is infallible. When there's no debuginfo the PC address is used as the function "name".
- `pp::backtrace`, pretty prints the processed frames preserving the current format. this is infallible API-wise (`println!` may still panic however)

there's more work that could have been done but has intentionally not been included in this commit, like making `unwind::target` and/or `symbolicate::frames` lazy to only do as much work as required by the `--max_backtrace_len` flag.

this commit also fixes issue 196 by making `--max_backtrace_len=1` print the right number of frames. The behavior of `--max_backtrace_len=0` has been changed to *never* print a backtrace (`--force-backtrace --max-backtrace-len=0` does *not* print a backtrace)

this commit also (non-exhaustively) groups Cortex-M constants and operations in a module to make them easier to spot (in case we ever add support for other architectures like RISC V). a qualified path, instead of an import, is used to access the items in that module.

we don't have automated tests for the backtrace but manual testing indicates that behavior is preserved. the warning message about the stack being corrupted now has less detail however.

fixes #196