### PR TITLE
add column info to backtrace

### DIFF
--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -26,7 +26,14 @@ pub(crate) fn backtrace(frames: &[Frame], max_backtrace_len: u32) {
                 println!("{:>4}: {}", frame_index, name);
 
                 if let Some(location) = &subroutine.location {
-                    println!("        at {}:{}", location.path.display(), location.line);
+                    let path = location.path.display();
+                    let line = location.line;
+                    let column = location
+                        .column
+                        .map(|column| Cow::Owned(format!(":{}", column)))
+                        .unwrap_or(Cow::Borrowed(""));
+
+                    println!("        at {}:{}{}", path, line, column);
                 }
 
                 frame_index += 1;

--- a/src/backtrace/symbolicate.rs
+++ b/src/backtrace/symbolicate.rs
@@ -116,11 +116,11 @@ impl Subroutine {
                 .map(Either::Left)
                 .unwrap_or_else(|| name_from_symtab(pc, symtab));
 
-            let location = if let Some((file, line)) = frame
-                .location
-                .as_ref()
-                .and_then(|loc| loc.file.and_then(|file| loc.line.map(|line| (file, line))))
-            {
+            let location = if let Some((file, line, column)) =
+                frame.location.as_ref().and_then(|loc| {
+                    loc.file
+                        .and_then(|file| loc.line.map(|line| (file, line, loc.column)))
+                }) {
                 let fullpath = Path::new(file);
                 let path = if let Ok(relpath) = fullpath.strip_prefix(&current_dir) {
                     relpath
@@ -129,6 +129,7 @@ impl Subroutine {
                 };
 
                 Some(Location {
+                    column,
                     line,
                     path: path.to_owned(),
                 })
@@ -169,6 +170,7 @@ fn name_from_symtab(pc: u32, symtab: &SymbolMap<SymbolMapName>) -> Either<String
 
 #[derive(Debug)]
 pub(crate) struct Location {
+    pub(crate) column: Option<u32>,
     pub(crate) line: u32,
     pub(crate) path: PathBuf,
 }


### PR DESCRIPTION
using the standard format: `$FILE:$LINE:$COLUMN` so ctrl-click-ing the path in VS code open the editor at the right place