### PR TITLE
backtrace: highlight frames that point to local code

### DIFF
--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -23,7 +23,19 @@ pub(crate) fn backtrace(frames: &[Frame], max_backtrace_len: u32) {
                     either::Either::Right(pc) => Cow::Owned(format!("??? (PC={:#010x})", pc)),
                 };
 
-                println!("{:>4}: {}", frame_index, name);
+                let is_local_function = subroutine
+                    .location
+                    .as_ref()
+                    .map(|location| location.path_is_relative)
+                    .unwrap_or(false);
+
+                let line = format!("{:>4}: {}", frame_index, name);
+                let colorized_line = if is_local_function {
+                    line.bold()
+                } else {
+                    line.normal()
+                };
+                println!("{}", colorized_line);
 
                 if let Some(location) = &subroutine.location {
                     let path = location.path.display();
@@ -33,7 +45,13 @@ pub(crate) fn backtrace(frames: &[Frame], max_backtrace_len: u32) {
                         .map(|column| Cow::Owned(format!(":{}", column)))
                         .unwrap_or(Cow::Borrowed(""));
 
-                    println!("        at {}:{}{}", path, line, column);
+                    let line = format!("        at {}:{}{}", path, line, column);
+                    let colorized_line = if is_local_function {
+                        line.normal()
+                    } else {
+                        line.dimmed()
+                    };
+                    println!("{}", colorized_line);
                 }
 
                 frame_index += 1;

--- a/src/backtrace/symbolicate.rs
+++ b/src/backtrace/symbolicate.rs
@@ -122,14 +122,15 @@ impl Subroutine {
                         .and_then(|file| loc.line.map(|line| (file, line, loc.column)))
                 }) {
                 let fullpath = Path::new(file);
-                let path = if let Ok(relpath) = fullpath.strip_prefix(&current_dir) {
-                    relpath
+                let (path, is_local) = if let Ok(relpath) = fullpath.strip_prefix(&current_dir) {
+                    (relpath, true)
                 } else {
-                    fullpath
+                    (fullpath, false)
                 };
 
                 Some(Location {
                     column,
+                    path_is_relative: is_local,
                     line,
                     path: path.to_owned(),
                 })
@@ -171,6 +172,7 @@ fn name_from_symtab(pc: u32, symtab: &SymbolMap<SymbolMapName>) -> Either<String
 #[derive(Debug)]
 pub(crate) struct Location {
     pub(crate) column: Option<u32>,
+    pub(crate) path_is_relative: bool,
     pub(crate) line: u32,
     pub(crate) path: PathBuf,
 }


### PR DESCRIPTION
using the heuristic: if the file location of the function is relative to the current directory then
it's "local code"

before:
![Screenshot from 2021-05-12 18-47-40](https://user-images.githubusercontent.com/5018213/118014181-33f0ab00-b353-11eb-8210-8c8210b062ac.png)
after:
![Screenshot from 2021-05-12 18-46-03](https://user-images.githubusercontent.com/5018213/118014195-38b55f00-b353-11eb-8fde-95150497a592.png)

I don't have too many opinions about *how* to highlight these frames so treat the above as a strawman proposal

cc #139 @Lotterleben 