### PR TITLE
add --shorten-paths

### DIFF
--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -13,6 +13,7 @@ pub(crate) struct Settings<'p> {
     pub(crate) current_dir: &'p Path,
     pub(crate) max_backtrace_len: u32,
     pub(crate) force_backtrace: bool,
+    pub(crate) compress_cratesio_dep_paths: bool,
 }
 
 /// (virtually) unwinds the target's program and prints its backtrace
@@ -45,7 +46,7 @@ pub(crate) fn print(
         || contains_exception;
 
     if print_backtrace && settings.max_backtrace_len > 0 {
-        pp::backtrace(&frames, settings.max_backtrace_len);
+        pp::backtrace(&frames, &settings);
 
         if unwind.corrupted {
             log::warn!("call stack was corrupted; unwinding could not be completed");

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -13,7 +13,7 @@ pub(crate) struct Settings<'p> {
     pub(crate) current_dir: &'p Path,
     pub(crate) max_backtrace_len: u32,
     pub(crate) force_backtrace: bool,
-    pub(crate) compress_cratesio_dep_paths: bool,
+    pub(crate) shorten_paths: bool,
 }
 
 /// (virtually) unwinds the target's program and prints its backtrace

--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -89,6 +89,9 @@ struct Dependency<'p> {
 }
 
 impl<'p> Dependency<'p> {
+    // as of Rust 1.52.1 this path looks like this on Linux
+    // /home/some-user/.cargo/registry/src/github.com-0123456789abcdef/crate-name-0.1.2/src/lib.rs
+    // on Windows the `/home/some-user` part becomes something else
     fn from_path(path: &'p Path) -> Option<Self> {
         if !path.is_absolute() {
             return None;

--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -40,8 +40,8 @@ pub(crate) fn backtrace(frames: &[Frame], settings: &Settings) {
                 println!("{}", colorized_line);
 
                 if let Some(location) = &subroutine.location {
-                    let path = if settings.compress_cratesio_dep_paths {
-                        utils::compress_cratesio_dep_path(&location.path)
+                    let path = if settings.shorten_paths {
+                        utils::shorten_paths(&location.path)
                     } else {
                         location.path.display().to_string()
                     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,10 @@ struct Opts {
     #[structopt(long, default_value = "50")]
     max_backtrace_len: u32,
 
+    /// Whether to compress the paths to crates.io dependencies
+    #[structopt(long)]
+    compress_cratesio_dep_paths: bool,
+
     /// Arguments passed after the ELF file path are discarded
     #[structopt(name = "REST")]
     _rest: Vec<String>,
@@ -136,6 +140,7 @@ fn notmain() -> anyhow::Result<i32> {
 
     let force_backtrace = opts.force_backtrace;
     let max_backtrace_len = opts.max_backtrace_len;
+    let compress_cratesio_dep_paths = opts.compress_cratesio_dep_paths;
     let elf_path = opts.elf.as_deref().unwrap();
     let chip = opts.chip.as_deref().unwrap();
     let bytes = fs::read(elf_path)?;
@@ -545,6 +550,7 @@ fn notmain() -> anyhow::Result<i32> {
         max_backtrace_len,
         // TODO any other cases in which we should force a backtrace?
         force_backtrace: force_backtrace || canary_touched || halted_due_to_signal,
+        compress_cratesio_dep_paths,
     };
 
     let outcome = backtrace::print(

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,9 +93,9 @@ struct Opts {
     #[structopt(long, default_value = "50")]
     max_backtrace_len: u32,
 
-    /// Whether to compress the paths to crates.io dependencies
+    /// Whether to shorten paths (e.g. to crates.io dependencies) in backtraces and defmt logs
     #[structopt(long)]
-    compress_cratesio_dep_paths: bool,
+    shorten_paths: bool,
 
     /// Arguments passed after the ELF file path are discarded
     #[structopt(name = "REST")]
@@ -141,7 +141,7 @@ fn notmain() -> anyhow::Result<i32> {
 
     let force_backtrace = opts.force_backtrace;
     let max_backtrace_len = opts.max_backtrace_len;
-    let compress_cratesio_dep_paths = opts.compress_cratesio_dep_paths;
+    let shorten_paths = opts.shorten_paths;
     let elf_path = opts.elf.as_deref().unwrap();
     let chip = opts.chip.as_deref().unwrap();
     let bytes = fs::read(elf_path)?;
@@ -459,8 +459,8 @@ fn notmain() -> anyhow::Result<i32> {
                                     let path =
                                         if let Ok(relpath) = loc.file.strip_prefix(&current_dir) {
                                             relpath.display().to_string()
-                                        } else if compress_cratesio_dep_paths {
-                                            utils::compress_cratesio_dep_path(&loc.file)
+                                        } else if shorten_paths {
+                                            utils::shorten_paths(&loc.file)
                                         } else {
                                             loc.file.display().to_string()
                                         };
@@ -553,7 +553,7 @@ fn notmain() -> anyhow::Result<i32> {
         max_backtrace_len,
         // TODO any other cases in which we should force a backtrace?
         force_backtrace: force_backtrace || canary_touched || halted_due_to_signal,
-        compress_cratesio_dep_paths,
+        shorten_paths,
     };
 
     let outcome = backtrace::print(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod backtrace;
 mod cortexm;
 mod registers;
 mod stacked;
+mod utils;
 
 use std::{
     collections::HashSet,
@@ -455,14 +456,16 @@ fn notmain() -> anyhow::Result<i32> {
 
                                 let (mut file, mut line, mut mod_path) = (None, None, None);
                                 if let Some(loc) = loc {
-                                    let relpath =
+                                    let path =
                                         if let Ok(relpath) = loc.file.strip_prefix(&current_dir) {
-                                            relpath
+                                            relpath.display().to_string()
+                                        } else if compress_cratesio_dep_paths {
+                                            utils::compress_cratesio_dep_path(&loc.file)
                                         } else {
-                                            // not relative; use full path
-                                            &loc.file
+                                            loc.file.display().to_string()
                                         };
-                                    file = Some(relpath.display().to_string());
+
+                                    file = Some(path);
                                     line = Some(loc.line as u32);
                                     mod_path = Some(loc.module.clone());
                                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+
+pub(crate) fn compress_cratesio_dep_path(path: &Path) -> String {
+    if let Some(dep) = Dependency::from_path(path) {
+        format!("[{}]/{}", dep.name_version, dep.path.display())
+    } else {
+        path.display().to_string()
+    }
+}
+
+struct Dependency<'p> {
+    name_version: &'p str,
+    path: &'p Path,
+}
+
+impl<'p> Dependency<'p> {
+    // as of Rust 1.52.1 this path looks like this on Linux
+    // /home/some-user/.cargo/registry/src/github.com-0123456789abcdef/crate-name-0.1.2/src/lib.rs
+    // on Windows the `/home/some-user` part becomes something else
+    fn from_path(path: &'p Path) -> Option<Self> {
+        if !path.is_absolute() {
+            return None;
+        }
+
+        let mut components = path.components();
+        let _registry = components.find(|component| match component {
+            std::path::Component::Normal(component) => *component == "registry",
+            _ => false,
+        })?;
+
+        if let std::path::Component::Normal(src) = components.next()? {
+            if src != "src" {
+                return None;
+            }
+        }
+
+        if let std::path::Component::Normal(github) = components.next()? {
+            let github = github.to_str()?;
+            if !github.starts_with("github.com-") {
+                return None;
+            }
+        }
+
+        if let std::path::Component::Normal(name_version) = components.next()? {
+            let name_version = name_version.to_str()?;
+            Some(Dependency {
+                name_version,
+                path: components.as_path(),
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-pub(crate) fn compress_cratesio_dep_path(path: &Path) -> String {
+pub(crate) fn shorten_paths(path: &Path) -> String {
     if let Some(dep) = Dependency::from_path(path) {
         format!("[{}]/{}", dep.name_version, dep.path.display())
     } else {


### PR DESCRIPTION
this flags compresses the paths to crates.io dependencies from full paths to
the format `[$cratename-$crateversion]/src/module/file.rs`

cc #66

---

before:
``` console
$ cargo rb hello
(..)
stack backtrace:
(..)
   4: main
        at src/bin/hello.rs:6:1
   5: ResetTrampoline
        at /home/japaric/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:547:26
   6: Reset
        at /home/japaric/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:550:13
```

after:
``` console
$ cargo rb hello
(..)
stack backtrace:
(..)
   4: main
        at src/bin/hello.rs:6:1
   5: ResetTrampoline
        at [cortex-m-rt-0.6.13]/src/lib.rs:547:26
   6: Reset
        at [cortex-m-rt-0.6.13]/src/lib.rs:550:13
```

currently only paths in the backtrace are modify (because that was the easiest thing to implement / test)

TODO:
- [x] also compress paths in defmt logs
