### PR TITLE
fix unwinding exceptions that push FPU registers onto the stack

### DIFF
--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -5,7 +5,7 @@ use std::{mem, ops::Range};
 use crate::VectorTable;
 
 pub(crate) const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
-pub(crate) const EXC_RETURN_MARKER: u32 = 0xFFFF_FFF0;
+pub(crate) const EXC_RETURN_MARKER: u32 = 0xFFFF_FFE0;
 const THUMB_BIT: u32 = 1;
 // According to the ARM Cortex-M Reference Manual RAM memory must be located in this address range
 // (vendors still place e.g. Core-Coupled RAM outside this address range)


### PR DESCRIPTION
the correct value of constant EXC_RETURN_MARKER is 0xFFFF_FFE0 but the value was typo-ed in the
refactor part of PR #163 

https://github.com/knurling-rs/probe-run/commit/226c6930dbcd0def0acb2dc51d0584a291c2f2bf#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL755