### PR TITLE
unwind: read as little stacked registers as possible

### DIFF
--- a/src/stacked.rs
+++ b/src/stacked.rs
@@ -4,7 +4,7 @@ use probe_rs::{Core, MemoryInterface};
 
 /// Registers stacked on exception entry.
 #[derive(Debug)]
-pub struct Stacked {
+pub(crate) struct Stacked {
     r0: u32,
     r1: u32,
     r2: u32,
@@ -12,8 +12,7 @@ pub struct Stacked {
     r12: u32,
     pub lr: u32,
     pub pc: u32,
-    xpsr: u32,
-    fpu_regs: Option<StackedFpuRegs>,
+    contains_fpu_regs: bool,
 }
 
 fn bounds_check(bounds: Range<u32>, start: u32, len: u32) -> Result<(), ()> {
@@ -26,6 +25,9 @@ fn bounds_check(bounds: Range<u32>, start: u32, len: u32) -> Result<(), ()> {
 }
 
 impl Stacked {
+    /// Minimum number of stacked registers that we need to read to be able to unwind an exception
+    const WORDS_MINIMUM: usize = 7;
+
     /// Number of 32-bit words stacked in a basic frame.
     const WORDS_BASIC: usize = 8;
 
@@ -41,12 +43,8 @@ impl Stacked {
         fpu: bool,
         ram_bounds: Range<u32>,
     ) -> anyhow::Result<Option<Self>> {
-        let mut storage = [0; Self::WORDS_EXTENDED];
-        let registers: &mut [_] = if fpu {
-            &mut storage
-        } else {
-            &mut storage[..Self::WORDS_BASIC]
-        };
+        let mut storage = [0; Self::WORDS_MINIMUM];
+        let registers: &mut [_] = &mut storage;
 
         if bounds_check(
             ram_bounds,
@@ -68,62 +66,18 @@ impl Stacked {
             r12: registers[4],
             lr: registers[5],
             pc: registers[6],
-            xpsr: registers[7],
-            fpu_regs: if fpu {
-                Some(StackedFpuRegs {
-                    s0: f32::from_bits(registers[8]),
-                    s1: f32::from_bits(registers[9]),
-                    s2: f32::from_bits(registers[10]),
-                    s3: f32::from_bits(registers[11]),
-                    s4: f32::from_bits(registers[12]),
-                    s5: f32::from_bits(registers[13]),
-                    s6: f32::from_bits(registers[14]),
-                    s7: f32::from_bits(registers[15]),
-                    s8: f32::from_bits(registers[16]),
-                    s9: f32::from_bits(registers[17]),
-                    s10: f32::from_bits(registers[18]),
-                    s11: f32::from_bits(registers[19]),
-                    s12: f32::from_bits(registers[20]),
-                    s13: f32::from_bits(registers[21]),
-                    s14: f32::from_bits(registers[22]),
-                    s15: f32::from_bits(registers[23]),
-                    fpscr: registers[24],
-                })
-            } else {
-                None
-            },
+            contains_fpu_regs: fpu,
         }))
     }
 
     /// Returns the in-memory size of these stacked registers, in Bytes.
     pub fn size(&self) -> u32 {
-        let num_words = if self.fpu_regs.is_none() {
-            Self::WORDS_BASIC
-        } else {
+        let num_words = if self.contains_fpu_regs {
             Self::WORDS_EXTENDED
+        } else {
+            Self::WORDS_BASIC
         };
 
         num_words as u32 * 4
     }
-}
-
-#[derive(Debug)]
-struct StackedFpuRegs {
-    s0: f32,
-    s1: f32,
-    s2: f32,
-    s3: f32,
-    s4: f32,
-    s5: f32,
-    s6: f32,
-    s7: f32,
-    s8: f32,
-    s9: f32,
-    s10: f32,
-    s11: f32,
-    s12: f32,
-    s13: f32,
-    s14: f32,
-    s15: f32,
-    fpscr: u32,
 }


### PR DESCRIPTION
the other registers that were being read are not used in the unwinding process
closes #187
(this doesn't appear to help with unwinding programs that are in a 'stack overflowed' state however)