### PR TITLE
WIP: make `unwind::target()` infallible

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -26,7 +26,7 @@ pub(crate) fn print(
     live_functions: &HashSet<&str>,
     settings: &Settings,
 ) -> anyhow::Result<Outcome> {
-    let unwind = unwind::target(core, debug_frame, vector_table, sp_ram_region)?;
+    let unwind = unwind::target(core, debug_frame, vector_table, sp_ram_region);
 
     let frames = symbolicate::frames(
         &unwind.raw_frames,
@@ -50,6 +50,13 @@ pub(crate) fn print(
 
         if unwind.corrupted {
             log::warn!("call stack was corrupted; unwinding could not be completed");
+        }
+        if let Some(err) = unwind.processing_error {
+            log::error!(
+                "error occurred during backtrace creation: {:?}\n               \
+                         the backtrace may be incomplete.",
+                err
+            );
         }
     }
 

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -1,6 +1,6 @@
 //! unwind target's program
 
-use anyhow::{ensure, Context as _};
+use anyhow::{anyhow, Context as _};
 use gimli::{
     BaseAddresses, DebugFrame, LittleEndian, UninitializedUnwindContext, UnwindSection as _,
 };
@@ -22,60 +22,68 @@ fn missing_debug_info(pc: u32) -> String {
 
 /// Virtually* unwinds the target's program
 /// \* destructors are not run
-// FIXME(?) this should be "infallible" and return as many frames as possible even in case of IO
-// errors
+///
+/// This returns as much info as could be collected, even if the collection is interrupted by an error.
+/// If an error occurred during processing, it is stored in `Output::processing_error`.
 pub(crate) fn target(
     core: &mut Core,
     debug_frame: &[u8],
     vector_table: &VectorTable,
     sp_ram_region: &Option<RamRegion>,
-) -> anyhow::Result<Output> {
+) -> Output {
+    let mut output = Output {
+        corrupted: true,
+        outcome: Outcome::Ok,
+        raw_frames: vec![],
+        processing_error: None,
+    };
+
+    /// Returns all info collected until the error occurred and puts the error into `processing_error`
+    macro_rules! unwrap_or_return_output {
+        ( $e:expr ) => {
+            match $e {
+                Ok(x) => x,
+                Err(err) => {
+                    output.processing_error = Some(anyhow!(err));
+                    return output;
+                }
+            }
+        };
+    }
+
     let mut debug_frame = DebugFrame::new(debug_frame, LittleEndian);
     debug_frame.set_address_size(cortexm::ADDRESS_SIZE);
 
-    let mut pc = core.read_core_reg(registers::PC)?;
-    let sp = core.read_core_reg(registers::SP)?;
-    let lr = core.read_core_reg(registers::LR)?;
+    let mut pc = unwrap_or_return_output!(core.read_core_reg(registers::PC));
+    let sp = unwrap_or_return_output!(core.read_core_reg(registers::SP));
+    let lr = unwrap_or_return_output!(core.read_core_reg(registers::LR));
     let base_addresses = BaseAddresses::default();
     let mut unwind_context = UninitializedUnwindContext::new();
-
-    let mut outcome = Outcome::Ok;
     let mut registers = Registers::new(lr, sp, core);
-    let mut raw_frames = vec![];
-    let mut corrupted = true;
 
     loop {
-        if cortexm::is_hard_fault(pc, vector_table) {
-            assert!(
-                raw_frames.is_empty(),
-                "when present HardFault handler must be the first frame we unwind but wasn't"
-            );
-
-            outcome = if overflowed_stack(sp, sp_ram_region) {
-                Outcome::StackOverflow
-            } else {
-                Outcome::HardFault
-            };
+        if let Some(outcome) = check_hard_fault(pc, vector_table, &mut output, sp, sp_ram_region) {
+            output.outcome = outcome;
         }
 
-        raw_frames.push(RawFrame::Subroutine { pc });
+        output.raw_frames.push(RawFrame::Subroutine { pc });
 
-        let uwt_row = debug_frame
+        let uwt_row = unwrap_or_return_output!(debug_frame
             .unwind_info_for_address(
                 &base_addresses,
                 &mut unwind_context,
                 pc.into(),
                 DebugFrame::cie_from_offset,
             )
-            .with_context(|| missing_debug_info(pc))?;
+            .with_context(|| missing_debug_info(pc)));
 
-        let cfa_changed = registers.update_cfa(uwt_row.cfa())?;
+        let cfa_changed = unwrap_or_return_output!(registers.update_cfa(uwt_row.cfa()));
 
         for (reg, rule) in uwt_row.registers() {
-            registers.update(reg, rule)?;
+            unwrap_or_return_output!(registers.update(reg, rule));
         }
 
-        let lr = registers.get(registers::LR)?;
+        let lr = unwrap_or_return_output!(registers.get(registers::LR));
 
         log::debug!("LR={:#010X} PC={:#010X}", lr, pc);
 
@@ -91,28 +99,29 @@ pub(crate) fn target(
 
         // If the frame didn't move, and the program counter didn't change, bail out (otherwise we
         // might print the same frame over and over).
-        corrupted = !cfa_changed && !program_counter_changed;
+        output.corrupted = !cfa_changed && !program_counter_changed;
 
-        if corrupted {
+        if output.corrupted {
             break;
         }
 
         if exception_entry {
-            raw_frames.push(RawFrame::Exception);
+            output.raw_frames.push(RawFrame::Exception);
 
             // Read the `FType` field from the `EXC_RETURN` value.
             let fpu = lr & cortexm::EXC_RETURN_FTYPE_MASK == 0;
 
-            let sp = registers.get(registers::SP)?;
+            let sp = unwrap_or_return_output!(registers.get(registers::SP));
             let ram_bounds = sp_ram_region
                 .as_ref()
                 .map(|ram_region| ram_region.range.clone())
                 .unwrap_or(cortexm::VALID_RAM_ADDRESS);
-            let stacked = if let Some(stacked) = Stacked::read(registers.core, sp, fpu, ram_bounds)?
+            let stacked = if let Some(stacked) =
+                unwrap_or_return_output!(Stacked::read(registers.core, sp, fpu, ram_bounds))
             {
                 stacked
             } else {
-                corrupted = true;
+                output.corrupted = true;
                 break;
             };
 
@@ -122,21 +131,41 @@ pub(crate) fn target(
 
             pc = stacked.pc;
         } else {
-            ensure!(
-                cortexm::is_thumb_bit_set(lr),
-                "bug? LR ({:#010x}) didn't have the Thumb bit set",
-                lr
-            );
-
-            pc = cortexm::clear_thumb_bit(lr);
+            if cortexm::is_thumb_bit_set(lr) {
+                pc = cortexm::clear_thumb_bit(lr);
+            } else {
+                output.processing_error = Some(anyhow!(
+                    "bug? LR ({:#010x}) didn't have the Thumb bit set",
+                    lr
+                ));
+                return output;
+            }
         }
     }
 
-    Ok(Output {
-        corrupted,
-        outcome,
-        raw_frames,
-    })
+    output
+}
+
+fn check_hard_fault(
+    pc: u32,
+    vector_table: &VectorTable,
+    output: &mut Output,
+    sp: u32,
+    sp_ram_region: &Option<RamRegion>,
+) -> Option<Outcome> {
+    if cortexm::is_hard_fault(pc, vector_table) {
+        assert!(
+            output.raw_frames.is_empty(),
+            "when present HardFault handler must be the first frame we unwind but wasn't"
+        );
+
+        if overflowed_stack(sp, sp_ram_region) {
+            return Some(Outcome::StackOverflow);
+        } else {
+            return Some(Outcome::HardFault);
+        }
+    }
+    None
 }
 
 #[derive(Debug)]
@@ -144,6 +173,9 @@ pub struct Output {
     pub(crate) corrupted: bool,
     pub(crate) outcome: Outcome,
     pub(crate) raw_frames: Vec<RawFrame>,
+    /// Will be `Some` if an error occured while putting together the output.
+    /// `outcome` and `raw_frames` will contain all info collected until the error occurred.
+    pub(crate) processing_error: Option<anyhow::Error>,
 }
 
 /// Backtrace frame prior to 'symbolication'


### PR DESCRIPTION
in Draft status because my approach to error conversion feels clunky and I did resort to using a macro, so any feedback would be appreciated