### PR TITLE
refactor the huge "main" function into smaller functions + module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,7 +562,6 @@ dependencies = [
  "addr2line",
  "ansi_term 0.12.1",
  "anyhow",
- "arrayref",
  "colored",
  "defmt-decoder",
  "difference",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.2.3"
 addr2line = "0.14.1"
 ansi_term = "0.12.1"
 anyhow = "1.0.40"
-arrayref = "0.3.6"
 colored = "2.0.0"
 defmt-decoder = { version = "=0.2.1", features = ['unstable'] }
 difference = "2.0.0"

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use probe_rs::{config::RamRegion, Core};
 
-use crate::sketch::ProcessedElf;
+use crate::elf::ProcessedElf;
 
 mod pp;
 mod symbolicate;

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use probe_rs::{config::RamRegion, Core};
 
-use crate::elf::ProcessedElf;
+use crate::elf::Elf;
 
 mod pp;
 mod symbolicate;
@@ -18,7 +18,7 @@ pub(crate) struct Settings<'p> {
 /// (virtually) unwinds the target's program and prints its backtrace
 pub(crate) fn print(
     core: &mut Core,
-    elf: &ProcessedElf,
+    elf: &Elf,
     active_ram_region: &Option<RamRegion>,
     settings: &Settings,
 ) -> anyhow::Result<Outcome> {

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -19,10 +19,10 @@ pub(crate) struct Settings<'p> {
 pub(crate) fn print(
     core: &mut Core,
     elf: &ProcessedElf,
-    sp_ram_region: &Option<RamRegion>,
+    active_ram_region: &Option<RamRegion>,
     settings: &Settings,
 ) -> anyhow::Result<Outcome> {
-    let unwind = unwind::target(core, elf, sp_ram_region);
+    let unwind = unwind::target(core, elf, active_ram_region);
 
     let frames = symbolicate::frames(&unwind.raw_frames, settings.current_dir, elf);
 

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -61,3 +61,29 @@ pub(crate) enum Outcome {
     Ok,
     StackOverflow,
 }
+
+impl Outcome {
+    pub(crate) fn log(&self) {
+        match self {
+            Outcome::StackOverflow => {
+                log::error!("the program has overflowed its stack");
+            }
+            Outcome::HardFault => {
+                log::error!("the program panicked");
+            }
+            Outcome::Ok => {
+                log::info!("device halted without error");
+            }
+        }
+    }
+}
+
+/// convert outomce into an exit code
+impl Into<i32> for Outcome {
+    fn into(self) -> i32 {
+        match self {
+            Outcome::HardFault | Outcome::StackOverflow => crate::SIGABRT,
+            Outcome::Ok => 0,
+        }
+    }
+}

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use probe_rs::{config::RamRegion, Core};
 
-use crate::{sketch::ProcessedElf, Outcome};
+use crate::sketch::ProcessedElf;
 
 mod pp;
 mod symbolicate;
@@ -52,4 +52,12 @@ pub(crate) fn print(
     }
 
     Ok(unwind.outcome)
+}
+
+/// Target program outcome
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum Outcome {
+    HardFault,
+    Ok,
+    StackOverflow,
 }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -78,7 +78,7 @@ impl Outcome {
     }
 }
 
-/// convert outomce into an exit code
+/// Converts `Outcome` to an exit code.
 impl From<Outcome> for i32 {
     fn from(outcome: Outcome) -> i32 {
         match outcome {

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -79,9 +79,9 @@ impl Outcome {
 }
 
 /// convert outomce into an exit code
-impl Into<i32> for Outcome {
-    fn into(self) -> i32 {
-        match self {
+impl From<Outcome> for i32 {
+    fn from(outcome: Outcome) -> i32 {
+        match outcome {
             Outcome::HardFault | Outcome::StackOverflow => crate::SIGABRT,
             Outcome::Ok => 0,
         }

--- a/src/backtrace/symbolicate.rs
+++ b/src/backtrace/symbolicate.rs
@@ -11,7 +11,7 @@ use either::Either;
 use gimli::{EndianReader, RunTimeEndian};
 use object::{Object as _, SymbolMap, SymbolMapName};
 
-use crate::{cortexm, sketch::ProcessedElf};
+use crate::{cortexm, elf::ProcessedElf};
 
 use super::unwind::RawFrame;
 

--- a/src/backtrace/symbolicate.rs
+++ b/src/backtrace/symbolicate.rs
@@ -11,15 +11,11 @@ use either::Either;
 use gimli::{EndianReader, RunTimeEndian};
 use object::{Object as _, SymbolMap, SymbolMapName};
 
-use crate::{cortexm, elf::ProcessedElf};
+use crate::{cortexm, elf::Elf};
 
 use super::unwind::RawFrame;
 
-pub(crate) fn frames(
-    raw_frames: &[RawFrame],
-    current_dir: &Path,
-    elf: &ProcessedElf,
-) -> Vec<Frame> {
+pub(crate) fn frames(raw_frames: &[RawFrame], current_dir: &Path, elf: &Elf) -> Vec<Frame> {
     let mut frames = vec![];
 
     let symtab = elf.symbol_map();

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -9,7 +9,7 @@ use probe_rs::{config::RamRegion, Core};
 use crate::{
     backtrace::Outcome,
     cortexm,
-    elf::ProcessedElf,
+    elf::Elf,
     registers::{self, Registers},
     stacked::Stacked,
 };
@@ -28,7 +28,7 @@ fn missing_debug_info(pc: u32) -> String {
 /// If an error occurred during processing, it is stored in `Output::processing_error`.
 pub(crate) fn target(
     core: &mut Core,
-    elf: &ProcessedElf,
+    elf: &Elf,
     active_ram_region: &Option<RamRegion>,
 ) -> Output {
     let mut output = Output {

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -10,7 +10,7 @@ use crate::{
     backtrace::Outcome,
     cortexm,
     registers::{self, Registers},
-    sketch::ProcessedElf,
+    elf::ProcessedElf,
     stacked::Stacked,
     VectorTable,
 };

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -7,11 +7,12 @@ use gimli::{
 use probe_rs::{config::RamRegion, Core};
 
 use crate::{
+    backtrace::Outcome,
     cortexm,
     registers::{self, Registers},
     sketch::ProcessedElf,
     stacked::Stacked,
-    Outcome, VectorTable,
+    VectorTable,
 };
 
 fn missing_debug_info(pc: u32) -> String {

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -1,0 +1,115 @@
+use crate::TIMEOUT;
+use crate::{cortexm, ProcessedElf, TargetInfo};
+use anyhow::bail;
+use probe_rs::{MemoryInterface, Session};
+use std::time::Duration;
+
+const STACK_CANARY: u8 = 0xAA;
+
+pub(crate) struct Canary {
+    address: u32,
+    size: usize,
+}
+
+pub(crate) fn touched(
+    canary: Option<Canary>,
+    core: &mut probe_rs::Core,
+    elf: &ProcessedElf,
+) -> anyhow::Result<bool> {
+    if let Some(canary) = canary {
+        let mut buf = vec![0; canary.size];
+        core.read_8(canary.address, &mut buf)?;
+
+        if let Some(pos) = buf.iter().position(|b| *b != STACK_CANARY) {
+            let touched_addr = canary.address + pos as u32;
+            log::debug!("canary was touched at 0x{:08X}", touched_addr);
+
+            let min_stack_usage = elf.vector_table.initial_stack_pointer - touched_addr;
+            log::warn!(
+                "program has used at least {} bytes of stack space, data segments \
+                may be corrupted due to stack overflow",
+                min_stack_usage,
+            );
+            return Ok(true);
+        } else {
+            log::debug!("stack canary intact");
+        }
+    }
+
+    Ok(false)
+}
+
+pub(crate) fn place(
+    sess: &mut Session,
+    target_info: &TargetInfo,
+    elf: &ProcessedElf,
+) -> Result<Option<Canary>, anyhow::Error> {
+    let mut canary = None;
+    {
+        let mut core = sess.core(0)?;
+        core.reset_and_halt(TIMEOUT)?;
+
+        // Decide if and where to place the stack canary.
+        if let (Some(ram), Some(highest_ram_addr_in_use)) = (
+            &target_info.active_ram_region,
+            target_info.highest_ram_addr_in_use,
+        ) {
+            // Initial SP must be past canary location.
+            let initial_sp_makes_sense = ram
+                .range
+                .contains(&(elf.vector_table.initial_stack_pointer - 1))
+                && highest_ram_addr_in_use < elf.vector_table.initial_stack_pointer;
+            if target_info.highest_ram_addr_in_use.is_some()
+                && !elf.target_program_uses_heap
+                && initial_sp_makes_sense
+            {
+                let stack_available =
+                    elf.vector_table.initial_stack_pointer - highest_ram_addr_in_use - 1;
+
+                // We consider >90% stack usage a potential stack overflow, but don't go beyond 1 kb since
+                // filling a lot of RAM is slow (and 1 kb should be "good enough" for what we're doing).
+                let canary_size = 1024.min(stack_available / 10) as usize;
+
+                log::debug!(
+                    "{} bytes of stack available (0x{:08X}-0x{:08X}), using {} byte canary to detect overflows",
+                    stack_available,
+                    highest_ram_addr_in_use + 1,
+                    elf.vector_table.initial_stack_pointer,
+                    canary_size,
+                );
+
+                // Canary starts right after `highest_ram_addr_in_use`.
+                let canary_addr = highest_ram_addr_in_use + 1;
+                canary = Some(Canary {
+                    address: canary_addr,
+                    size: canary_size,
+                });
+                let data = vec![STACK_CANARY; canary_size];
+                core.write_8(canary_addr, &data)?;
+            }
+        }
+
+        log::debug!("starting device");
+        if core.get_available_breakpoint_units()? == 0 {
+            if elf.rtt_buffer_address.is_some() {
+                bail!("RTT not supported on device without HW breakpoints");
+            } else {
+                log::warn!("device doesn't support HW breakpoints; HardFault will NOT make `probe-run` exit with an error code");
+            }
+        }
+
+        if let Some(rtt) = elf.rtt_buffer_address {
+            core.set_hw_breakpoint(elf.main_function_address)?;
+            core.run()?;
+            core.wait_for_core_halted(Duration::from_secs(5))?;
+            const OFFSET: u32 = 44;
+            const FLAG: u32 = 2; // BLOCK_IF_FULL
+            core.write_word_32(rtt + OFFSET, FLAG)?;
+            core.clear_hw_breakpoint(elf.main_function_address)?;
+        }
+
+        core.set_hw_breakpoint(cortexm::clear_thumb_bit(elf.vector_table.hard_fault))?;
+        core.run()?;
+    }
+    Ok(canary)
+}

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -52,14 +52,14 @@ pub(crate) fn place(
         // Decide if and where to place the stack canary.
         if let (Some(ram), Some(highest_ram_addr_in_use)) = (
             &target_info.active_ram_region,
-            target_info.highest_ram_addr_in_use,
+            target_info.highest_ram_address_in_use,
         ) {
             // Initial SP must be past canary location.
             let initial_sp_makes_sense = ram
                 .range
                 .contains(&(elf.vector_table.initial_stack_pointer - 1))
                 && highest_ram_addr_in_use < elf.vector_table.initial_stack_pointer;
-            if target_info.highest_ram_addr_in_use.is_some()
+            if target_info.highest_ram_address_in_use.is_some()
                 && !elf.target_program_uses_heap()
                 && initial_sp_makes_sense
             {

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -57,7 +57,7 @@ impl Canary {
             let standard_memory_layout =
                 highest_static_var_address < elf.vector_table.initial_stack_pointer;
 
-            if !elf.target_program_uses_heap() && standard_memory_layout {
+            if !elf.program_uses_heap() && standard_memory_layout {
                 let stack_available =
                     elf.vector_table.initial_stack_pointer - highest_static_var_address - 1;
 

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -1,5 +1,5 @@
 use crate::TIMEOUT;
-use crate::{cortexm, ProcessedElf, TargetInfo};
+use crate::{cortexm, Elf, TargetInfo};
 use anyhow::bail;
 use probe_rs::{MemoryInterface, Session};
 use std::time::Duration;
@@ -14,7 +14,7 @@ pub(crate) struct Canary {
 pub(crate) fn touched(
     canary: Option<Canary>,
     core: &mut probe_rs::Core,
-    elf: &ProcessedElf,
+    elf: &Elf,
 ) -> anyhow::Result<bool> {
     if let Some(canary) = canary {
         let mut buf = vec![0; canary.size];
@@ -42,7 +42,7 @@ pub(crate) fn touched(
 pub(crate) fn place(
     sess: &mut Session,
     target_info: &TargetInfo,
-    elf: &ProcessedElf,
+    elf: &Elf,
 ) -> Result<Option<Canary>, anyhow::Error> {
     let mut canary = None;
     {

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -30,12 +30,12 @@ const CANARY_VALUE: u8 = 0xAA;
 /// The whole canary is initialized to `CANARY_VALUE` before the target program is started.
 /// The canary size is 10% of the available stack space or 1 KiB, whichever is smallest.
 ///
-/// When the programs ends (due to panic or breakpoint) the integrity canary is checked. If it was
+/// When the programs ends (due to panic or breakpoint) the integrity of the canary is checked. If it was
 /// "touched" (any of its bytes != `CANARY_VALUE`) then that is considered to be a *potential* stack
-/// overflow
+/// overflow.
 ///
 /// The canary is not installed if the program memory layout is "inverted" (stack is *below* the
-/// static variables)
+/// static variables).
 #[derive(Clone, Copy)]
 pub(crate) struct Canary {
     address: u32,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,131 @@
+use std::path::PathBuf;
+
+use log::Level;
+use probe_rs::config::registry;
+use probe_rs::Probe;
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+
+/// Successfull termination of process.
+const EXIT_SUCCESS: i32 = 0;
+
+/// A Cargo runner for microcontrollers.
+#[derive(StructOpt)]
+#[structopt(name = "probe-run", setting = AppSettings::TrailingVarArg)]
+pub(crate) struct Opts {
+    /// List supported chips and exit.
+    #[structopt(long)]
+    list_chips: bool,
+
+    /// Lists all the connected probes and exit.
+    #[structopt(long)]
+    list_probes: bool,
+
+    /// The chip to program.
+    #[structopt(long, required_unless_one(&["list-chips", "list-probes", "version"]), env = "PROBE_RUN_CHIP")]
+    chip: Option<String>,
+
+    /// The probe to use (eg. `VID:PID`, `VID:PID:Serial`, or just `Serial`).
+    #[structopt(long, env = "PROBE_RUN_PROBE")]
+    pub(crate) probe: Option<String>,
+
+    /// The probe clock frequency in kHz
+    #[structopt(long)]
+    pub(crate) speed: Option<u32>,
+
+    /// Path to an ELF firmware file.
+    #[structopt(name = "ELF", parse(from_os_str), required_unless_one(&["list-chips", "list-probes", "version"]))]
+    elf: Option<PathBuf>,
+
+    /// Skip writing the application binary to flash.
+    #[structopt(long, conflicts_with = "defmt")]
+    pub(crate) no_flash: bool,
+
+    /// Connect to device when NRST is pressed.
+    #[structopt(long)]
+    pub(crate) connect_under_reset: bool,
+
+    /// Enable more verbose logging.
+    #[structopt(short, long, parse(from_occurrences))]
+    verbose: u32,
+
+    /// Prints version information
+    #[structopt(short = "V", long)]
+    version: bool,
+
+    /// Print a backtrace even if the program ran successfully
+    #[structopt(long)]
+    pub(crate) force_backtrace: bool,
+
+    /// Configure the number of lines to print before a backtrace gets cut off
+    #[structopt(long, default_value = "50")]
+    pub(crate) max_backtrace_len: u32,
+
+    /// Whether to shorten paths (e.g. to crates.io dependencies) in backtraces and defmt logs
+    #[structopt(long)]
+    pub(crate) shorten_paths: bool,
+
+    /// Arguments passed after the ELF file path are discarded
+    #[structopt(name = "REST")]
+    _rest: Vec<String>,
+}
+
+pub(crate) fn handle_arguments() -> anyhow::Result<i32> {
+    let opts: Opts = Opts::from_args();
+    let verbose = opts.verbose;
+
+    defmt_decoder::log::init_logger(verbose >= 1, move |metadata| {
+        if defmt_decoder::log::is_defmt_frame(metadata) {
+            true // We want to display *all* defmt frames.
+        } else {
+            // Log depending on how often the `--verbose` (`-v`) cli-param is supplied:
+            //   * 0: log everything from probe-run, with level "info" or higher
+            //   * 1: log everything from probe-run
+            //   * 2 or more: log everything
+            if verbose >= 2 {
+                true
+            } else if verbose >= 1 {
+                metadata.target().starts_with("probe_run")
+            } else {
+                metadata.target().starts_with("probe_run") && metadata.level() <= Level::Info
+            }
+        }
+    });
+
+    if opts.version {
+        print_version();
+        Ok(EXIT_SUCCESS)
+    } else if opts.list_probes {
+        crate::print_probes(Probe::list_all());
+        Ok(EXIT_SUCCESS)
+    } else if opts.list_chips {
+        print_chips();
+        Ok(EXIT_SUCCESS)
+    } else if let (Some(elf), Some(chip)) = (opts.elf.as_deref(), opts.chip.as_deref()) {
+        crate::run_target_program(elf, chip, &opts)
+    } else {
+        unreachable!("due to `StructOpt` constraints")
+    }
+}
+
+fn print_chips() {
+    let registry = registry::families().expect("Could not retrieve chip family registry");
+    for chip_family in registry {
+        println!("{}\n    Variants:", chip_family.name);
+        for variant in chip_family.variants.iter() {
+            println!("        {}", variant.name);
+        }
+    }
+}
+
+/// The string reported by the `--version` flag
+fn print_version() {
+    const VERSION: &str = env!("CARGO_PKG_VERSION"); // version from Cargo.toml e.g. "0.1.4"
+    const HASH: &str = include_str!(concat!(env!("OUT_DIR"), "/git-info.txt")); // "" OR git hash e.g. "34019f8" -- this is generated in build.rs
+    println!(
+        "{}{}\nsupported defmt version: {}",
+        VERSION,
+        HASH,
+        defmt_decoder::DEFMT_VERSION
+    );
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,7 +98,7 @@ pub(crate) fn handle_arguments() -> anyhow::Result<i32> {
         print_version();
         Ok(EXIT_SUCCESS)
     } else if opts.list_probes {
-        probe::print(Probe::list_all());
+        probe::print(&Probe::list_all());
         Ok(EXIT_SUCCESS)
     } else if opts.list_chips {
         print_chips();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,8 @@ use probe_rs::Probe;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
+use crate::probe;
+
 /// Successfull termination of process.
 const EXIT_SUCCESS: i32 = 0;
 
@@ -96,7 +98,7 @@ pub(crate) fn handle_arguments() -> anyhow::Result<i32> {
         print_version();
         Ok(EXIT_SUCCESS)
     } else if opts.list_probes {
-        crate::print_probes(Probe::list_all());
+        probe::print(Probe::list_all());
         Ok(EXIT_SUCCESS)
     } else if opts.list_chips {
         print_chips();

--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -2,6 +2,8 @@
 
 use std::{mem, ops::Range};
 
+use gimli::LittleEndian;
+
 pub(crate) const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
 
 /// According to Armv8-M Architecture Reference Manual, the most significant 8 bits are `0xFF` to
@@ -9,6 +11,9 @@ pub(crate) const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
 pub(crate) const EXC_RETURN_MARKER: u32 = 0xFF00_0000;
 
 pub(crate) const EXC_RETURN_FTYPE_MASK: u32 = 1 << 4;
+
+pub(crate) const ENDIANESS: LittleEndian = LittleEndian;
+pub(crate) type ENDIANESS = LittleEndian;
 
 const THUMB_BIT: u32 = 1;
 // According to the ARM Cortex-M Reference Manual RAM memory must be located in this address range

--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -12,8 +12,8 @@ pub(crate) const EXC_RETURN_MARKER: u32 = 0xFF00_0000;
 
 pub(crate) const EXC_RETURN_FTYPE_MASK: u32 = 1 << 4;
 
-pub(crate) const ENDIANESS: LittleEndian = LittleEndian;
-pub(crate) type ENDIANESS = LittleEndian;
+pub(crate) const ENDIANNESS: LittleEndian = LittleEndian;
+pub(crate) type Endianness = LittleEndian;
 
 const THUMB_BIT: u32 = 1;
 // According to the ARM Cortex-M Reference Manual RAM memory must be located in this address range

--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -2,8 +2,6 @@
 
 use std::{mem, ops::Range};
 
-use crate::VectorTable;
-
 pub(crate) const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
 
 /// According to Armv8-M Architecture Reference Manual, the most significant 8 bits are `0xFF` to
@@ -38,4 +36,16 @@ pub(crate) fn set_thumb_bit(addr: u32) -> u32 {
 /// Checks if two subroutine addresses are equivalent by first clearing their `THUMB_BIT`
 pub(crate) fn subroutine_eq(addr1: u32, addr2: u32) -> bool {
     addr1 & !THUMB_BIT == addr2 & !THUMB_BIT
+}
+
+/// The contents of the vector table
+#[derive(Debug)]
+pub(crate) struct VectorTable {
+    pub(crate) location: u32,
+    // entry 0
+    pub(crate) initial_stack_pointer: u32,
+    // entry 1: Reset handler
+    pub(crate) reset: u32,
+    // entry 3: HardFault handler
+    pub(crate) hard_fault: u32,
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -13,7 +13,10 @@ use defmt_decoder::Table;
 use object::{
     read::File as ElfFile, Object, ObjectSection, ObjectSegment, ObjectSymbol, SymbolSection,
 };
-use probe_rs::Target;
+use probe_rs::{
+    config::{MemoryRegion, RamRegion},
+    Target,
+};
 
 use crate::cortexm;
 
@@ -243,13 +246,11 @@ fn extract_symbols(elf: &ElfFile) -> anyhow::Result<(Option<u32>, /* uses heap: 
 
 pub(crate) struct DataFromProbeRsRegistry {
     target: Target,
-    //ram_region_that_contains_stack: u32,
 }
 
 impl DataFromProbeRsRegistry {
     pub(crate) fn new(chip: &str) -> anyhow::Result<Self> {
         let target = probe_rs::config::registry::get_target_by_name(chip)?;
-
         Ok(Self { target })
     }
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -244,23 +244,23 @@ fn extract_symbols(elf: &ElfFile) -> anyhow::Result<(Option<u32>, /* uses heap: 
     ))
 }
 
-pub(crate) struct DataFromProbeRsRegistry {
+pub(crate) struct TargetInfo {
     pub(crate) target: Target,
-    pub(crate) sp_ram_region: Option<RamRegion>,
+    pub(crate) active_ram_region: Option<RamRegion>,
 }
 
-impl DataFromProbeRsRegistry {
+impl TargetInfo {
     pub(crate) fn new(chip: &str, initial_sp: u32) -> anyhow::Result<Self> {
         let target = probe_rs::config::registry::get_target_by_name(chip)?;
-        let sp_ram_region = extract_sp_ram_region(&target, initial_sp);
+        let active_ram_region = extract_active_ram_region(&target, initial_sp);
         Ok(Self {
             target,
-            sp_ram_region,
+            active_ram_region,
         })
     }
 }
 
-fn extract_sp_ram_region(target: &Target, initial_sp: u32) -> Option<RamRegion> {
+fn extract_active_ram_region(target: &Target, initial_sp: u32) -> Option<RamRegion> {
     target
         .memory_map
         .iter()

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -13,10 +13,6 @@ use defmt_decoder::Table;
 use object::{
     read::File as ElfFile, Object, ObjectSection, ObjectSegment, ObjectSymbol, SymbolSection,
 };
-use probe_rs::{
-    config::{MemoryRegion, RamRegion},
-    Target,
-};
 
 use crate::cortexm;
 
@@ -242,75 +238,6 @@ fn extract_symbols(elf: &ElfFile) -> anyhow::Result<(Option<u32>, /* uses heap: 
         uses_heap,
         main.ok_or_else(|| anyhow!("`main` symbol not found"))?,
     ))
-}
-
-pub(crate) struct TargetInfo {
-    pub(crate) target: Target,
-    pub(crate) active_ram_region: Option<RamRegion>,
-    pub(crate) highest_ram_addr_in_use: Option<u32>, // todo maybe merge
-}
-
-impl TargetInfo {
-    pub(crate) fn new(chip: &str, elf: &ProcessedElf) -> anyhow::Result<Self> {
-        let target = probe_rs::config::registry::get_target_by_name(chip)?;
-        let active_ram_region =
-            extract_active_ram_region(&target, elf.vector_table.initial_stack_pointer);
-        let highest_ram_addr_in_use =
-            extract_highest_ram_addr_in_use(elf, active_ram_region.as_ref())?;
-        Ok(Self {
-            target,
-            active_ram_region,
-            highest_ram_addr_in_use,
-        })
-    }
-}
-
-fn extract_active_ram_region(target: &Target, initial_sp: u32) -> Option<RamRegion> {
-    target
-        .memory_map
-        .iter()
-        .filter_map(|region| match region {
-            MemoryRegion::Ram(region) => {
-                // NOTE stack is full descending; meaning the stack pointer can be
-                // `ORIGIN(RAM) + LENGTH(RAM)`
-                let range = region.range.start..=region.range.end;
-                if range.contains(&initial_sp) {
-                    Some(region)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        })
-        .next()
-        .cloned()
-}
-
-fn extract_highest_ram_addr_in_use(
-    elf: &ElfFile,
-    active_ram_region: Option<&RamRegion>,
-) -> anyhow::Result<Option<u32>> {
-    let mut highest_ram_addr_in_use = None;
-    for sect in elf.sections() {
-        // If this section resides in RAM, track the highest RAM address in use.
-        if let Some(ram) = active_ram_region {
-            if sect.size() != 0 {
-                let last_addr = sect.address() + sect.size() - 1;
-                let last_addr = last_addr.try_into()?;
-                if ram.range.contains(&last_addr) {
-                    log::debug!(
-                        "section `{}` is in RAM at 0x{:08X}-0x{:08X}",
-                        sect.name().unwrap_or("<unknown>"),
-                        sect.address(),
-                        last_addr,
-                    );
-                    highest_ram_addr_in_use = highest_ram_addr_in_use.max(Some(last_addr));
-                }
-            }
-        }
-    }
-
-    Ok(highest_ram_addr_in_use)
 }
 
 // obtained via probe-rs?

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,12 +1,7 @@
-use std::{
-    collections::{BTreeMap, HashSet},
-    convert::TryInto,
-    env,
-    ops::Deref,
-};
+use std::{collections::HashSet, convert::TryInto, env, ops::Deref};
 
 use anyhow::{anyhow, bail};
-use defmt_decoder::{Location, Table};
+use defmt_decoder::{Locations, Table};
 use object::{
     read::File as ObjectFile, Object, ObjectSection, ObjectSegment, ObjectSymbol, SymbolSection,
 };
@@ -100,8 +95,6 @@ fn extract_live_functions<'file>(elf: &ObjectFile<'file>) -> anyhow::Result<Hash
 
     Ok(live_functions)
 }
-
-type Locations = BTreeMap<u64, Location>;
 
 fn extract_defmt_info(elf_bytes: &[u8]) -> anyhow::Result<(Option<Table>, Option<Locations>)> {
     let defmt_table = match env::var("PROBE_RUN_IGNORE_VERSION").as_deref() {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -103,7 +103,8 @@ impl<'file> Elf<'file> {
         })
     }
 
-    pub(crate) fn program_size(&self) -> u64 {
+    /// Returns the size of the part of the program allocated in Flash
+    pub(crate) fn program_flash_size(&self) -> u64 {
         // `segments` iterates only over *loadable* segments,
         // which are the segments that will be loaded to Flash by probe-rs
         self.elf.segments().map(|segment| segment.size()).sum()

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use anyhow::{anyhow, bail};
-use arrayref::array_ref;
 use defmt_decoder::{Location, Table};
 use object::{
     read::File as ObjectFile, Object, ObjectSection, ObjectSegment, ObjectSymbol, SymbolSection,
@@ -145,7 +144,7 @@ fn extract_vector_table(elf: &ObjectFile) -> anyhow::Result<cortexm::VectorTable
     let bytes = section.data()?;
     let mut words = bytes
         .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(*array_ref!(chunk, 0, 4)));
+        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()));
 
     if let (Some(initial_stack_pointer), Some(reset), Some(_third), Some(hard_fault)) =
         (words.next(), words.next(), words.next(), words.next())

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO remove this
-
 use std::{
     collections::{BTreeMap, HashSet},
     convert::TryInto,
@@ -15,45 +13,6 @@ use object::{
 };
 
 use crate::cortexm;
-
-pub(crate) fn notmain() -> anyhow::Result<i32> {
-    // - parse CL arguments
-    // - parse ELF -> grouped into `ProcessedElf` struct
-    //   -> RAM region
-    //   -> location of RTT buffer
-    //   -> vector table
-    // - extra defmt table from ELF
-    // - filter & connect to probe & configure
-    // - flash the chip (optionally)
-    // - write stack overflow canary in RAM
-    // - set breakpoint
-    // - start target program
-    // - when paused, set RTT in blocking mode
-    // - set breakpoint in HardFault handler
-    // - resume target program
-    // while !signal_received {
-    //   - read RTT data
-    //   - decode defmt logs from RTT data
-    //   - print defmt logs
-    //   - if core.is_halted() break
-    // }
-    // - if signal_received, halt the core
-    // - [core is halted at this point]
-    // - stack overflow check = check canary in RAM region
-    // - print backtrace
-    // - reset halt device to put peripherals in known state
-    // - print exit reason
-
-    todo!()
-}
-
-struct BacktraceInput {
-    probe: (),
-    // .debug_frame section
-    debug_frame: (),
-    // used for addr2line in frame symbolication
-    elf: (),
-}
 
 pub(crate) struct Elf<'file> {
     // original ELF (object crate)
@@ -242,10 +201,3 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<(Option<u32>, /* uses hea
         main.ok_or_else(|| anyhow!("`main` symbol not found"))?,
     ))
 }
-
-// obtained via probe-rs?
-// struct DataFromRunningTarget {}
-
-// fn parse_cl_arguments() -> ClArguments {
-
-// }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -83,6 +83,8 @@ impl<'file> ProcessedElf<'file> {
 
         let (defmt_table, defmt_locations) = extract_defmt_info(elf_bytes)?;
         let vector_table = extract_vector_table(&elf)?;
+        log::debug!("vector table: {:x?}", vector_table);
+
         let debug_frame = extract_debug_frame(&elf)?;
 
         let (rtt_buffer_address, target_program_uses_heap, address_of_main_function) =

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod dep;
 mod elf;
 mod registers;
 mod stacked;
+mod target_info;
 
 use std::{
     env, fs,
@@ -29,8 +30,7 @@ use probe_rs_rtt::{Rtt, ScanRegion, UpChannel};
 use signal_hook::consts::signal;
 use structopt::{clap::AppSettings, StructOpt};
 
-use crate::elf::ProcessedElf;
-use crate::{backtrace::Outcome, elf::TargetInfo};
+use crate::{backtrace::Outcome, elf::ProcessedElf, target_info::TargetInfo};
 
 /// Successfull termination of process.
 const EXIT_SUCCESS: i32 = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 mod backtrace;
 mod cortexm;
 mod dep;
+mod elf;
 mod registers;
-mod sketch;
 mod stacked;
 
 use std::{
@@ -35,7 +35,7 @@ use signal_hook::consts::signal;
 use structopt::{clap::AppSettings, StructOpt};
 
 use crate::backtrace::Outcome;
-use crate::sketch::ProcessedElf;
+use crate::elf::ProcessedElf;
 
 /// Successfull termination of process.
 const EXIT_SUCCESS: i32 = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,47 +154,6 @@ fn notmain() -> anyhow::Result<i32> {
 
     let target = DataFromProbeRsRegistry::new(chip)?;
 
-    // find and report the RAM region
-    let mut ram_region = None;
-    for region in &target.memory_map {
-        if let MemoryRegion::Ram(ram) = region {
-            if let Some(old) = &ram_region {
-                log::debug!("multiple RAM regions found ({:?} and {:?}), stack canary will not be available", old, ram);
-            } else {
-                ram_region = Some(ram.clone());
-            }
-        }
-    }
-    if let Some(ram) = &ram_region {
-        log::debug!(
-            "RAM region: 0x{:08X}-0x{:08X}",
-            ram.range.start,
-            ram.range.end - 1
-        );
-    }
-    let ram_region = ram_region;
-
-    // TODO use this instead of iterating?
-    let mut highest_ram_addr_in_use = 0;
-    for sect in elf.sections() {
-        // If this section resides in RAM, track the highest RAM address in use.
-        if let Some(ram) = &ram_region {
-            if sect.size() != 0 {
-                let last_addr = sect.address() + sect.size() - 1;
-                let last_addr = last_addr.try_into()?;
-                if ram.range.contains(&last_addr) {
-                    log::debug!(
-                        "section `{}` is in RAM at 0x{:08X}-0x{:08X}",
-                        sect.name().unwrap_or("<unknown>"),
-                        sect.address(),
-                        last_addr,
-                    );
-                    highest_ram_addr_in_use = highest_ram_addr_in_use.max(last_addr);
-                }
-            }
-        }
-    }
-
     // TODO continue looking at code from here
     log::debug!("vector table: {:x?}", elf.vector_table);
     let sp_ram_region = target
@@ -215,6 +174,27 @@ fn notmain() -> anyhow::Result<i32> {
         })
         .next()
         .cloned();
+
+    // TODO use this instead of iterating?
+    let mut highest_ram_addr_in_use = 0;
+    for sect in elf.sections() {
+        // If this section resides in RAM, track the highest RAM address in use.
+        if let Some(ram) = &sp_ram_region {
+            if sect.size() != 0 {
+                let last_addr = sect.address() + sect.size() - 1;
+                let last_addr = last_addr.try_into()?;
+                if ram.range.contains(&last_addr) {
+                    log::debug!(
+                        "section `{}` is in RAM at 0x{:08X}-0x{:08X}",
+                        sect.name().unwrap_or("<unknown>"),
+                        sect.address(),
+                        last_addr,
+                    );
+                    highest_ram_addr_in_use = highest_ram_addr_in_use.max(last_addr);
+                }
+            }
+        }
+    }
 
     let probes = Probe::list_all();
     let probes = if let Some(probe_opt) = opts.probe.as_deref() {
@@ -264,7 +244,7 @@ fn notmain() -> anyhow::Result<i32> {
         core.reset_and_halt(TIMEOUT)?;
 
         // Decide if and where to place the stack canary.
-        if let Some(ram) = &ram_region {
+        if let Some(ram) = &sp_ram_region {
             // Initial SP must be past canary location.
             let initial_sp_makes_sense = ram
                 .range

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,8 @@ use probe_rs_rtt::{Rtt, ScanRegion, UpChannel};
 use signal_hook::consts::signal;
 use structopt::{clap::AppSettings, StructOpt};
 
-use crate::backtrace::Outcome;
 use crate::elf::ProcessedElf;
+use crate::{backtrace::Outcome, elf::DataFromProbeRsRegistry};
 
 /// Successfull termination of process.
 const EXIT_SUCCESS: i32 = 0;
@@ -152,7 +152,7 @@ fn notmain() -> anyhow::Result<i32> {
     let bytes = fs::read(elf_path)?;
     let mut elf = ProcessedElf::from_elf(&bytes)?;
 
-    let target = probe_rs::config::registry::get_target_by_name(chip)?;
+    let target = DataFromProbeRsRegistry::new(chip)?;
 
     // find and report the RAM region
     let mut ram_region = None;
@@ -240,6 +240,7 @@ fn notmain() -> anyhow::Result<i32> {
         probe.set_speed(speed)?;
     }
 
+    let target: probe_rs::Target = target.into();
     let mut sess = if opts.connect_under_reset {
         probe.attach_under_reset(target)?
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,7 @@ fn run_target_program(elf_path: &Path, chip: &str, opts: &cli::Opts) -> anyhow::
 
     let target_info = TargetInfo::new(chip, &elf)?;
 
-    let mut probe = probe::open(opts)?;
-
-    if let Some(speed) = opts.speed {
-        probe.set_speed(speed)?;
-    }
+    let probe = probe::open(opts)?;
 
     let target = target_info.target.clone();
     let mut sess = if opts.connect_under_reset {
@@ -67,9 +63,9 @@ fn run_target_program(elf_path: &Path, chip: &str, opts: &cli::Opts) -> anyhow::
     if opts.no_flash {
         log::info!("skipped flashing");
     } else {
-        // program lives in Flash
-        let size = elf.program_size();
+        let size = elf.program_flash_size();
         log::info!("flashing program ({:.02} KiB)", size as f64 / 1024.0);
+
         flashing::download_file(&mut sess, elf_path, Format::Elf)?;
         log::info!("success!");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,8 +239,6 @@ fn notmain() -> anyhow::Result<i32> {
             }
         }
     }
-    // ???
-    let (debug_frame, vector_table) = (debug_frame, vector_table);
 
     let (rtt_addr, uses_heap, main) = get_rtt_heap_main_from(&elf)?;
 
@@ -562,6 +560,12 @@ fn program_size_of(file: &ElfFile) -> u64 {
     // `segments` iterates only over *loadable* segments,
     // which are the segments that will be loaded to Flash by probe-rs
     file.segments().map(|segment| segment.size()).sum()
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TopException {
+    StackOverflow,
+    HardFault, // generic hard fault
 }
 
 fn setup_logging_channel(

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn extract_and_print_logs(
     let exit = Arc::new(AtomicBool::new(false));
     let sigid = signal_hook::flag::register(signal::SIGINT, exit.clone())?;
 
-    let mut logging_channel = setup_logging_channel(elf.rtt_buffer_address, sess.clone())?;
+    let mut logging_channel = setup_logging_channel(elf.rtt_buffer_address(), sess.clone())?;
 
     let use_defmt = logging_channel
         .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,15 +485,7 @@ fn notmain() -> anyhow::Result<i32> {
         shorten_paths,
     };
 
-    let outcome = backtrace::print(
-        &mut core,
-        elf.debug_frame,
-        &elf,
-        &elf.vector_table,
-        &sp_ram_region,
-        &elf.live_functions,
-        &backtrace_settings,
-    )?;
+    let outcome = backtrace::print(&mut core, &elf, &sp_ram_region, &backtrace_settings)?;
 
     core.reset_and_halt(TIMEOUT)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn start_program(sess: &mut Session, elf: &Elf) -> Result<(), anyhow::Error> {
     }
 
     if let Some(rtt) = elf.rtt_buffer_address() {
-        let main = elf.main_function_address();
+        let main = elf.main_fn_address();
         core.set_hw_breakpoint(main)?;
         core.run()?;
         core.wait_for_core_halted(Duration::from_secs(5))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use probe_rs::{
 use probe_rs_rtt::{Rtt, ScanRegion, UpChannel};
 use signal_hook::consts::signal;
 
-use crate::{backtrace::Outcome, elf::Elf, target_info::TargetInfo};
+use crate::{elf::Elf, target_info::TargetInfo};
 
 const SIGABRT: i32 = 134;
 const TIMEOUT: Duration = Duration::from_secs(1);
@@ -99,20 +99,8 @@ fn run_target_program(elf_path: &Path, chip: &str, opts: &cli::Opts) -> anyhow::
 
     core.reset_and_halt(TIMEOUT)?;
 
-    Ok(match outcome {
-        Outcome::StackOverflow => {
-            log::error!("the program has overflowed its stack");
-            SIGABRT
-        }
-        Outcome::HardFault => {
-            log::error!("the program panicked");
-            SIGABRT
-        }
-        Outcome::Ok => {
-            log::info!("device halted without error");
-            0
-        }
-    })
+    outcome.log();
+    Ok(outcome.into())
 }
 
 fn extract_and_print_logs(

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,15 +677,3 @@ fn get_rtt_heap_main_from(
         main.ok_or_else(|| anyhow!("`main` symbol not found"))?,
     ))
 }
-
-/// The contents of the vector table
-#[derive(Debug)]
-struct VectorTable {
-    location: u32,
-    // entry 0
-    initial_stack_pointer: u32,
-    // entry 1: Reset handler
-    reset: u32,
-    // entry 3: HardFault handler
-    hard_fault: u32,
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use probe_rs_rtt::{Rtt, ScanRegion, UpChannel};
 use signal_hook::consts::signal;
 use structopt::{clap::AppSettings, StructOpt};
 
+use crate::backtrace::Outcome;
 use crate::sketch::ProcessedElf;
 
 /// Successfull termination of process.
@@ -687,12 +688,4 @@ struct VectorTable {
     reset: u32,
     // entry 3: HardFault handler
     hard_fault: u32,
-}
-
-/// Target program outcome
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum Outcome {
-    HardFault,
-    Ok,
-    StackOverflow,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,9 +154,7 @@ fn notmain() -> anyhow::Result<i32> {
     }
     let chip = opts.chip.as_deref().unwrap();
     let bytes = fs::read(elf_path)?;
-    let elf = ElfFile::parse(&bytes)?;
-
-    // let processed_elf = ProcessedElf::from_elf(elf);
+    let elf = ProcessedElf::from_elf(&bytes)?;
 
     let target = probe_rs::config::registry::get_target_by_name(chip)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,12 +177,7 @@ fn notmain() -> anyhow::Result<i32> {
     let ram_region = ram_region;
 
     // TODO use this instead of iterating?
-    // let _: Option<_> = elf.section(".debug_frame")
     let mut highest_ram_addr_in_use = 0;
-    let debug_frame = elf
-        .section_by_name(".debug_frame")
-        .map(|section| section.data())
-        .transpose()?;
     for sect in elf.sections() {
         // If this section resides in RAM, track the highest RAM address in use.
         if let Some(ram) = &ram_region {
@@ -479,9 +474,6 @@ fn notmain() -> anyhow::Result<i32> {
         }
     }
 
-    // TODO can we call this earlier?
-    let debug_frame = debug_frame.ok_or_else(|| anyhow!("`.debug_frame` section not found"))?;
-
     print_separator();
 
     let halted_due_to_signal = exit.load(Ordering::Relaxed);
@@ -495,7 +487,7 @@ fn notmain() -> anyhow::Result<i32> {
 
     let outcome = backtrace::print(
         &mut core,
-        debug_frame,
+        elf.debug_frame,
         &elf,
         &elf.vector_table,
         &sp_ram_region,

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,10 +179,11 @@ fn notmain() -> anyhow::Result<i32> {
         probe.set_speed(speed)?;
     }
 
+    let target = target_info.target.clone();
     let mut sess = if opts.connect_under_reset {
-        probe.attach_under_reset(target_info.target)?
+        probe.attach_under_reset(target)?
     } else {
-        probe.attach(target_info.target)?
+        probe.attach(target)?
     };
     log::debug!("started session");
 
@@ -196,71 +197,7 @@ fn notmain() -> anyhow::Result<i32> {
         log::info!("success!");
     }
 
-    let mut canary = None;
-    {
-        let mut core = sess.core(0)?;
-        core.reset_and_halt(TIMEOUT)?;
-
-        // Decide if and where to place the stack canary.
-        if let (Some(ram), Some(highest_ram_addr_in_use)) = (
-            &target_info.active_ram_region,
-            target_info.highest_ram_addr_in_use,
-        ) {
-            // Initial SP must be past canary location.
-            let initial_sp_makes_sense = ram
-                .range
-                .contains(&(elf.vector_table.initial_stack_pointer - 1))
-                && highest_ram_addr_in_use < elf.vector_table.initial_stack_pointer;
-            if target_info.highest_ram_addr_in_use.is_some()
-                && !elf.target_program_uses_heap
-                && initial_sp_makes_sense
-            {
-                let stack_available =
-                    elf.vector_table.initial_stack_pointer - highest_ram_addr_in_use - 1;
-
-                // We consider >90% stack usage a potential stack overflow, but don't go beyond 1 kb since
-                // filling a lot of RAM is slow (and 1 kb should be "good enough" for what we're doing).
-                let canary_size = 1024.min(stack_available / 10);
-
-                log::debug!(
-                    "{} bytes of stack available (0x{:08X}-0x{:08X}), using {} byte canary to detect overflows",
-                    stack_available,
-                    highest_ram_addr_in_use + 1,
-                    elf.vector_table.initial_stack_pointer,
-                    canary_size,
-                );
-
-                // Canary starts right after `highest_ram_addr_in_use`.
-                let canary_addr = highest_ram_addr_in_use + 1;
-                canary = Some((canary_addr, canary_size));
-                let data = vec![STACK_CANARY; canary_size as usize];
-                core.write_8(canary_addr, &data)?;
-            }
-        }
-
-        log::debug!("starting device");
-        if core.get_available_breakpoint_units()? == 0 {
-            if elf.rtt_buffer_address.is_some() {
-                bail!("RTT not supported on device without HW breakpoints");
-            } else {
-                log::warn!("device doesn't support HW breakpoints; HardFault will NOT make `probe-run` exit with an error code");
-            }
-        }
-
-        if let Some(rtt) = elf.rtt_buffer_address {
-            core.set_hw_breakpoint(elf.main_function_address)?;
-            core.run()?;
-            core.wait_for_core_halted(Duration::from_secs(5))?;
-            const OFFSET: u32 = 44;
-            const FLAG: u32 = 2; // BLOCK_IF_FULL
-            core.write_word_32(rtt + OFFSET, FLAG)?;
-            core.clear_hw_breakpoint(elf.main_function_address)?;
-        }
-
-        core.set_hw_breakpoint(cortexm::clear_thumb_bit(elf.vector_table.hard_fault))?;
-        core.run()?;
-    }
-    let canary = canary;
+    let canary = place_stack_canary(&mut sess, &target_info, &elf)?;
 
     // Register a signal handler that sets `exit` to `true` on Ctrl+C. On the second Ctrl+C, the
     // signal's default action will be run.
@@ -395,12 +332,12 @@ fn notmain() -> anyhow::Result<i32> {
 
     // TODO move into own function?
     let mut canary_touched = false;
-    if let Some((addr, len)) = canary {
-        let mut buf = vec![0; len as usize];
-        core.read_8(addr as u32, &mut buf)?;
+    if let Some(canary) = canary {
+        let mut buf = vec![0; canary.size];
+        core.read_8(canary.address, &mut buf)?;
 
         if let Some(pos) = buf.iter().position(|b| *b != STACK_CANARY) {
-            let touched_addr = addr + pos as u32;
+            let touched_addr = canary.address + pos as u32;
             log::debug!("canary was touched at 0x{:08X}", touched_addr);
 
             let min_stack_usage = elf.vector_table.initial_stack_pointer - touched_addr;
@@ -449,6 +386,86 @@ fn notmain() -> anyhow::Result<i32> {
             0
         }
     })
+}
+
+struct Canary {
+    address: u32,
+    size: usize,
+}
+
+fn place_stack_canary(
+    sess: &mut Session,
+    target_info: &TargetInfo,
+    elf: &ProcessedElf,
+) -> Result<Option<Canary>, anyhow::Error> {
+    let mut canary = None;
+    {
+        let mut core = sess.core(0)?;
+        core.reset_and_halt(TIMEOUT)?;
+
+        // Decide if and where to place the stack canary.
+        if let (Some(ram), Some(highest_ram_addr_in_use)) = (
+            &target_info.active_ram_region,
+            target_info.highest_ram_addr_in_use,
+        ) {
+            // Initial SP must be past canary location.
+            let initial_sp_makes_sense = ram
+                .range
+                .contains(&(elf.vector_table.initial_stack_pointer - 1))
+                && highest_ram_addr_in_use < elf.vector_table.initial_stack_pointer;
+            if target_info.highest_ram_addr_in_use.is_some()
+                && !elf.target_program_uses_heap
+                && initial_sp_makes_sense
+            {
+                let stack_available =
+                    elf.vector_table.initial_stack_pointer - highest_ram_addr_in_use - 1;
+
+                // We consider >90% stack usage a potential stack overflow, but don't go beyond 1 kb since
+                // filling a lot of RAM is slow (and 1 kb should be "good enough" for what we're doing).
+                let canary_size = 1024.min(stack_available / 10) as usize;
+
+                log::debug!(
+                    "{} bytes of stack available (0x{:08X}-0x{:08X}), using {} byte canary to detect overflows",
+                    stack_available,
+                    highest_ram_addr_in_use + 1,
+                    elf.vector_table.initial_stack_pointer,
+                    canary_size,
+                );
+
+                // Canary starts right after `highest_ram_addr_in_use`.
+                let canary_addr = highest_ram_addr_in_use + 1;
+                canary = Some(Canary {
+                    address: canary_addr,
+                    size: canary_size,
+                });
+                let data = vec![STACK_CANARY; canary_size];
+                core.write_8(canary_addr, &data)?;
+            }
+        }
+
+        log::debug!("starting device");
+        if core.get_available_breakpoint_units()? == 0 {
+            if elf.rtt_buffer_address.is_some() {
+                bail!("RTT not supported on device without HW breakpoints");
+            } else {
+                log::warn!("device doesn't support HW breakpoints; HardFault will NOT make `probe-run` exit with an error code");
+            }
+        }
+
+        if let Some(rtt) = elf.rtt_buffer_address {
+            core.set_hw_breakpoint(elf.main_function_address)?;
+            core.run()?;
+            core.wait_for_core_halted(Duration::from_secs(5))?;
+            const OFFSET: u32 = 44;
+            const FLAG: u32 = 2; // BLOCK_IF_FULL
+            core.write_word_32(rtt + OFFSET, FLAG)?;
+            core.clear_hw_breakpoint(elf.main_function_address)?;
+        }
+
+        core.set_hw_breakpoint(cortexm::clear_thumb_bit(elf.vector_table.hard_fault))?;
+        core.run()?;
+    }
+    Ok(canary)
 }
 
 fn setup_logging_channel(

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,8 +186,6 @@ fn notmain() -> anyhow::Result<i32> {
     // let _: Option<_> = elf.section(".debug_frame")
     let mut highest_ram_addr_in_use = 0;
     let mut debug_frame = None;
-    // TODO remove this
-    let mut sections = vec![];
     let mut vector_table = None;
     for sect in elf.sections() {
         // If this section resides in RAM, track the highest RAM address in use.
@@ -238,8 +236,6 @@ fn notmain() -> anyhow::Result<i32> {
                         hard_fault: data[3],
                     });
                 }
-
-                sections.push(Section { start, data });
             }
         }
     }
@@ -568,12 +564,6 @@ fn program_size_of(file: &ElfFile) -> u64 {
     file.segments().map(|segment| segment.size()).sum()
 }
 
-#[derive(Debug, PartialEq)]
-pub enum TopException {
-    StackOverflow,
-    HardFault, // generic hard fault
-}
-
 fn setup_logging_channel(
     rtt_addr: Option<u32>,
     sess: Arc<Mutex<Session>>,
@@ -732,14 +722,6 @@ fn get_rtt_heap_main_from(
         uses_heap,
         main.ok_or_else(|| anyhow!("`main` symbol not found"))?,
     ))
-}
-
-// TODO remove this
-/// ELF section to be loaded onto the target
-#[derive(Debug)]
-struct Section {
-    start: u32,
-    data: Vec<u32>,
 }
 
 /// The contents of the vector table

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod backtrace;
 mod cortexm;
 mod dep;
 mod registers;
+mod sketch;
 mod stacked;
 
 use std::{
@@ -34,6 +35,8 @@ use probe_rs::{
 use probe_rs_rtt::{Rtt, ScanRegion, UpChannel};
 use signal_hook::consts::signal;
 use structopt::{clap::AppSettings, StructOpt};
+
+use crate::sketch::ProcessedElf;
 
 /// Successfull termination of process.
 const EXIT_SUCCESS: i32 = 0;
@@ -152,6 +155,8 @@ fn notmain() -> anyhow::Result<i32> {
     let chip = opts.chip.as_deref().unwrap();
     let bytes = fs::read(elf_path)?;
     let elf = ElfFile::parse(&bytes)?;
+
+    // let processed_elf = ProcessedElf::from_elf(elf);
 
     let target = probe_rs::config::registry::get_target_by_name(chip)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod backtrace;
+mod canary;
 mod cortexm;
 mod dep;
 mod elf;
@@ -24,7 +25,7 @@ use log::Level;
 use probe_rs::{
     config::registry,
     flashing::{self, Format},
-    DebugProbeInfo, MemoryInterface, Probe, Session,
+    DebugProbeInfo, Probe, Session,
 };
 use probe_rs_rtt::{Rtt, ScanRegion, UpChannel};
 use signal_hook::consts::signal;
@@ -34,7 +35,6 @@ use crate::{backtrace::Outcome, elf::ProcessedElf, target_info::TargetInfo};
 
 /// Successfull termination of process.
 const EXIT_SUCCESS: i32 = 0;
-const STACK_CANARY: u8 = 0xAA;
 const SIGABRT: i32 = 134;
 const TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -197,7 +197,7 @@ fn notmain() -> anyhow::Result<i32> {
         log::info!("success!");
     }
 
-    let canary = place_stack_canary(&mut sess, &target_info, &elf)?;
+    let canary = canary::place(&mut sess, &target_info, &elf)?;
 
     // Register a signal handler that sets `exit` to `true` on Ctrl+C. On the second Ctrl+C, the
     // signal's default action will be run.
@@ -332,7 +332,7 @@ fn notmain() -> anyhow::Result<i32> {
 
     print_separator();
 
-    let canary_touched = canary_touched(canary, &mut core, &elf)?;
+    let canary_touched = canary::touched(canary, &mut core, &elf)?;
     let halted_due_to_signal = exit.load(Ordering::Relaxed);
     let backtrace_settings = backtrace::Settings {
         current_dir: &current_dir,
@@ -365,114 +365,6 @@ fn notmain() -> anyhow::Result<i32> {
             0
         }
     })
-}
-
-fn canary_touched(
-    canary: Option<Canary>,
-    core: &mut probe_rs::Core,
-    elf: &ProcessedElf,
-) -> anyhow::Result<bool> {
-    if let Some(canary) = canary {
-        let mut buf = vec![0; canary.size];
-        core.read_8(canary.address, &mut buf)?;
-
-        if let Some(pos) = buf.iter().position(|b| *b != STACK_CANARY) {
-            let touched_addr = canary.address + pos as u32;
-            log::debug!("canary was touched at 0x{:08X}", touched_addr);
-
-            let min_stack_usage = elf.vector_table.initial_stack_pointer - touched_addr;
-            log::warn!(
-                "program has used at least {} bytes of stack space, data segments \
-                may be corrupted due to stack overflow",
-                min_stack_usage,
-            );
-            return Ok(true);
-        } else {
-            log::debug!("stack canary intact");
-        }
-    }
-
-    Ok(false)
-}
-
-struct Canary {
-    address: u32,
-    size: usize,
-}
-
-fn place_stack_canary(
-    sess: &mut Session,
-    target_info: &TargetInfo,
-    elf: &ProcessedElf,
-) -> Result<Option<Canary>, anyhow::Error> {
-    let mut canary = None;
-    {
-        let mut core = sess.core(0)?;
-        core.reset_and_halt(TIMEOUT)?;
-
-        // Decide if and where to place the stack canary.
-        if let (Some(ram), Some(highest_ram_addr_in_use)) = (
-            &target_info.active_ram_region,
-            target_info.highest_ram_addr_in_use,
-        ) {
-            // Initial SP must be past canary location.
-            let initial_sp_makes_sense = ram
-                .range
-                .contains(&(elf.vector_table.initial_stack_pointer - 1))
-                && highest_ram_addr_in_use < elf.vector_table.initial_stack_pointer;
-            if target_info.highest_ram_addr_in_use.is_some()
-                && !elf.target_program_uses_heap
-                && initial_sp_makes_sense
-            {
-                let stack_available =
-                    elf.vector_table.initial_stack_pointer - highest_ram_addr_in_use - 1;
-
-                // We consider >90% stack usage a potential stack overflow, but don't go beyond 1 kb since
-                // filling a lot of RAM is slow (and 1 kb should be "good enough" for what we're doing).
-                let canary_size = 1024.min(stack_available / 10) as usize;
-
-                log::debug!(
-                    "{} bytes of stack available (0x{:08X}-0x{:08X}), using {} byte canary to detect overflows",
-                    stack_available,
-                    highest_ram_addr_in_use + 1,
-                    elf.vector_table.initial_stack_pointer,
-                    canary_size,
-                );
-
-                // Canary starts right after `highest_ram_addr_in_use`.
-                let canary_addr = highest_ram_addr_in_use + 1;
-                canary = Some(Canary {
-                    address: canary_addr,
-                    size: canary_size,
-                });
-                let data = vec![STACK_CANARY; canary_size];
-                core.write_8(canary_addr, &data)?;
-            }
-        }
-
-        log::debug!("starting device");
-        if core.get_available_breakpoint_units()? == 0 {
-            if elf.rtt_buffer_address.is_some() {
-                bail!("RTT not supported on device without HW breakpoints");
-            } else {
-                log::warn!("device doesn't support HW breakpoints; HardFault will NOT make `probe-run` exit with an error code");
-            }
-        }
-
-        if let Some(rtt) = elf.rtt_buffer_address {
-            core.set_hw_breakpoint(elf.main_function_address)?;
-            core.run()?;
-            core.wait_for_core_halted(Duration::from_secs(5))?;
-            const OFFSET: u32 = 44;
-            const FLAG: u32 = 2; // BLOCK_IF_FULL
-            core.write_word_32(rtt + OFFSET, FLAG)?;
-            core.clear_hw_breakpoint(elf.main_function_address)?;
-        }
-
-        core.set_hw_breakpoint(cortexm::clear_thumb_bit(elf.vector_table.hard_fault))?;
-        core.run()?;
-    }
-    Ok(canary)
 }
 
 fn setup_logging_channel(

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -21,7 +21,7 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     log::debug!("found {} probes", filtered_probes.len());
 
     if filtered_probes.len() > 1 {
-        let _ = print(filtered_probes);
+        print(filtered_probes);
         bail!("more than one probe found; use --probe to specify which one to use");
     }
 
@@ -50,15 +50,15 @@ pub(crate) fn print(probes: Vec<DebugProbeInfo>) {
 fn filter(probes: &[DebugProbeInfo], selector: &ProbeFilter) -> Vec<DebugProbeInfo> {
     probes
         .iter()
-        .filter(|&p| {
+        .filter(|probe| {
             if let Some((vid, pid)) = selector.vid_pid {
-                if p.vendor_id != vid || p.product_id != pid {
+                if probe.vendor_id != vid || probe.product_id != pid {
                     return false;
                 }
             }
 
             if let Some(serial) = &selector.serial {
-                if p.serial_number.as_deref() != Some(serial) {
+                if probe.serial_number.as_deref() != Some(serial) {
                     return false;
                 }
             }
@@ -79,7 +79,7 @@ impl FromStr for ProbeFilter {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts = s.split(':').collect::<Vec<_>>();
-        match &*parts {
+        match *parts {
             [serial] => Ok(Self {
                 vid_pid: None,
                 serial: Some(serial.to_string()),

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -21,7 +21,7 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     log::debug!("found {} probes", filtered_probes.len());
 
     if filtered_probes.len() > 1 {
-        print(filtered_probes);
+        print(&filtered_probes);
         bail!("more than one probe found; use --probe to specify which one to use");
     }
 
@@ -35,7 +35,7 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     Ok(probe)
 }
 
-pub(crate) fn print(probes: Vec<DebugProbeInfo>) {
+pub(crate) fn print(probes: &[DebugProbeInfo]) {
     if !probes.is_empty() {
         println!("The following devices were found:");
         probes

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -1,0 +1,93 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, bail};
+use probe_rs::{DebugProbeInfo, Probe};
+
+use crate::cli;
+
+pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
+    let all_probes = Probe::list_all();
+    let filtered_probes = if let Some(probe_opt) = opts.probe.as_deref() {
+        let selector = probe_opt.parse()?;
+        filter(&all_probes, &selector)
+    } else {
+        all_probes
+    };
+
+    if filtered_probes.is_empty() {
+        bail!("no probe was found")
+    }
+
+    log::debug!("found {} probes", filtered_probes.len());
+
+    if filtered_probes.len() > 1 {
+        let _ = print(filtered_probes);
+        bail!("more than one probe found; use --probe to specify which one to use");
+    }
+
+    let probe = filtered_probes[0].open()?;
+    log::debug!("opened probe");
+    Ok(probe)
+}
+
+pub(crate) fn print(probes: Vec<DebugProbeInfo>) {
+    if !probes.is_empty() {
+        println!("The following devices were found:");
+        probes
+            .iter()
+            .enumerate()
+            .for_each(|(num, link)| println!("[{}]: {:?}", num, link));
+    } else {
+        println!("No devices were found.");
+    }
+}
+
+fn filter(probes: &[DebugProbeInfo], selector: &ProbeFilter) -> Vec<DebugProbeInfo> {
+    probes
+        .iter()
+        .filter(|&p| {
+            if let Some((vid, pid)) = selector.vid_pid {
+                if p.vendor_id != vid || p.product_id != pid {
+                    return false;
+                }
+            }
+
+            if let Some(serial) = &selector.serial {
+                if p.serial_number.as_deref() != Some(serial) {
+                    return false;
+                }
+            }
+
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+struct ProbeFilter {
+    vid_pid: Option<(u16, u16)>,
+    serial: Option<String>,
+}
+
+impl FromStr for ProbeFilter {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split(':').collect::<Vec<_>>();
+        match &*parts {
+            [serial] => Ok(Self {
+                vid_pid: None,
+                serial: Some(serial.to_string()),
+            }),
+            [vid, pid] => Ok(Self {
+                vid_pid: Some((u16::from_str_radix(vid, 16)?, u16::from_str_radix(pid, 16)?)),
+                serial: None,
+            }),
+            [vid, pid, serial] => Ok(Self {
+                vid_pid: Some((u16::from_str_radix(vid, 16)?, u16::from_str_radix(pid, 16)?)),
+                serial: Some(serial.to_string()),
+            }),
+            _ => Err(anyhow!("invalid probe filter")),
+        }
+    }
+}

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -25,8 +25,13 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
         bail!("more than one probe found; use --probe to specify which one to use");
     }
 
-    let probe = filtered_probes[0].open()?;
+    let mut probe = filtered_probes[0].open()?;
     log::debug!("opened probe");
+
+    if let Some(speed) = opts.speed {
+        probe.set_speed(speed)?;
+    }
+
     Ok(probe)
 }
 

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -53,7 +53,7 @@ pub(crate) struct ProcessedElf<'file> {
     elf: ElfFile<'file>,
     // name of functions in program after linking
     // extracted from `.text` section
-    live_functions: HashSet<&'file str>,
+    pub(crate) live_functions: HashSet<&'file str>,
     // // extracted using `defmt` crate
     // map(index: usize) -> defmt frame
     defmt_table: Option<Table>,

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -1,0 +1,76 @@
+pub(crate) fn notmain() -> anyhow::Result<i32> {
+    // - parse CL arguments
+    // - parse ELF -> grouped into `ProcessedElf` struct
+    //   -> RAM region
+    //   -> location of RTT buffer
+    //   -> vector table
+    // - extra defmt table from ELF
+    // - filter & connect to probe & configure
+    // - flash the chip (optionally)
+    // - write stack overflow canary in RAM
+    // - set breakpoint
+    // - start target program
+    // - when paused, set RTT in blocking mode
+    // - set breakpoint in HardFault handler
+    // - resume target program
+    // while !signal_received {
+    //   - read RTT data
+    //   - decode defmt logs from RTT data
+    //   - print defmt logs
+    //   - if core.is_halted() break
+    // }
+    // - if signal_received, halt the core
+    // - [core is halted at this point]
+    // - stack overflow check = check canary in RAM region
+    // - print backtrace
+    // - reset halt device to put peripherals in known state
+    // - print exit reason
+
+    todo!()
+}
+
+struct BacktraceInput {
+    probe: (),
+    // .debug_frame section
+    debug_frame: (),
+    // used for addr2line in frame symbolication
+    elf: (),
+}
+
+struct ProcessedElf {
+    elf: (), // original ELF (object crate)
+
+    // extracted from `.text` section
+    live_functions: (), // name of functinos in program after linking
+
+    // extracted using `defmt` crate
+    defmt_table: (),     // map(index: usize) -> defmt frame
+    defmt_locations: (), // map(index: usize) -> source code location
+
+    // extracted from `for` loop over symbols
+    target_program_uses_heap: (),
+    rtt_buffer_address: (),
+    address_of_main_function: (),
+
+    // currently extracted via `for` loop over sections
+    debug_frame: (),                // gimli one (not bytes)
+    vector_table: (),               // processed one (not bytes)
+    highest_ram_address_in_use: (), // used for stack canary
+}
+
+// impl ProcessedELf {
+//     fn symbol_map(&self) -> SymbolMap {
+//         self.elf.symbol_map()
+//     }
+// }
+
+struct DataFromProbeRsRegistry {
+    ram_region_that_contains_stack: (),
+}
+
+// obtained via probe-rs?
+// struct DataFromRunningTarget {}
+
+// fn parse_cl_arguments() -> ClArguments {
+
+// }

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -1,3 +1,13 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    env, fs,
+    path::Path,
+};
+
+use anyhow::anyhow;
+use defmt_decoder::Table;
+use object::{read::File as ElfFile, Object, ObjectSection, ObjectSymbol, SymbolSection};
+
 pub(crate) fn notmain() -> anyhow::Result<i32> {
     // - parse CL arguments
     // - parse ELF -> grouped into `ProcessedElf` struct
@@ -37,32 +47,92 @@ struct BacktraceInput {
     elf: (),
 }
 
-struct ProcessedElf {
-    elf: (), // original ELF (object crate)
-
+pub(crate) struct ProcessedElf<'file> {
+    // original ELF (object crate)
+    elf: ElfFile<'file>,
+    // name of functions in program after linking
     // extracted from `.text` section
-    live_functions: (), // name of functinos in program after linking
+    live_functions: HashSet<&'file str>,
+    // // extracted using `defmt` crate
+    // map(index: usize) -> defmt frame
+    defmt_table: Option<Table>,
+    // defmt_locations: (), // map(index: usize) -> source code location
 
-    // extracted using `defmt` crate
-    defmt_table: (),     // map(index: usize) -> defmt frame
-    defmt_locations: (), // map(index: usize) -> source code location
+    // // extracted from `for` loop over symbols
+    // target_program_uses_heap: (),
+    // rtt_buffer_address: (),
+    // address_of_main_function: (),
 
-    // extracted from `for` loop over symbols
-    target_program_uses_heap: (),
-    rtt_buffer_address: (),
-    address_of_main_function: (),
-
-    // currently extracted via `for` loop over sections
-    debug_frame: (),                // gimli one (not bytes)
-    vector_table: (),               // processed one (not bytes)
-    highest_ram_address_in_use: (), // used for stack canary
+    // // currently extracted via `for` loop over sections
+    // debug_frame: (),                // gimli one (not bytes)
+    // vector_table: (),               // processed one (not bytes)
+    // highest_ram_address_in_use: (), // used for stack canary
 }
 
-// impl ProcessedELf {
-//     fn symbol_map(&self) -> SymbolMap {
-//         self.elf.symbol_map()
-//     }
-// }
+impl<'file> ProcessedElf<'file> {
+    pub(crate) fn from_elf(elf_bytes: &'file [u8]) -> Result<Self, anyhow::Error> {
+        let elf = ElfFile::parse(elf_bytes)?;
+
+        let live_functions = extract_live_functions(&elf)?;
+
+        let defmt_table = extract_defmt_info(elf_bytes)?;
+
+        Ok(Self {
+            defmt_table,
+            elf,
+            live_functions,
+        })
+    }
+    //     fn symbol_map(&self) -> SymbolMap {
+    //         self.elf.symbol_map()
+    //     }
+}
+
+fn extract_defmt_info(elf_bytes: &[u8]) -> Result<Option<Table>, anyhow::Error> {
+    let mut defmt_table = match env::var("PROBE_RUN_IGNORE_VERSION").as_deref() {
+        Ok("true") | Ok("1") => defmt_decoder::Table::parse_ignore_version(elf_bytes)?,
+        _ => defmt_decoder::Table::parse(elf_bytes)?,
+    };
+    let mut defmt_locations = None;
+    if let Some(table) = defmt_table.as_ref() {
+        let tmp = table.get_locations(elf_bytes)?;
+
+        if !table.is_empty() && tmp.is_empty() {
+            log::warn!("insufficient DWARF info; compile your program with `debug = 2` to enable location info");
+        } else if table.indices().all(|idx| tmp.contains_key(&(idx as u64))) {
+            defmt_locations = Some(tmp);
+        } else {
+            log::warn!("(BUG) location info is incomplete; it will be omitted from the output");
+        }
+    }
+    Ok(defmt_table)
+}
+
+fn extract_live_functions<'file>(
+    elf: &ElfFile<'file>,
+) -> Result<HashSet<&'file str>, anyhow::Error> {
+    let text = elf
+        .section_by_name(".text")
+        .map(|section| section.index())
+        .ok_or_else(|| {
+            anyhow!(
+                "`.text` section is missing, please make sure that the linker script was passed \
+                to the linker (check `.cargo/config.toml` and the `RUSTFLAGS` variable)"
+            )
+        })?;
+
+    let live_functions = elf
+        .symbols()
+        .filter_map(|sym| {
+            if sym.section() == SymbolSection::Section(text) {
+                Some(sym.name())
+            } else {
+                None
+            }
+        })
+        .collect::<Result<HashSet<_>, _>>()?;
+    Ok(live_functions)
+}
 
 struct DataFromProbeRsRegistry {
     ram_region_that_contains_stack: (),

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -70,8 +70,8 @@ pub(crate) struct ProcessedElf<'file> {
 
     // // currently extracted via `for` loop over sections
     // debug_frame: (),                // gimli one (not bytes)
-    // vector_table: (),               // processed one (not bytes)
-    // highest_ram_address_in_use: (), // used for stack canary
+    pub(crate) vector_table: VectorTable, // processed one (not bytes)
+                                          // highest_ram_address_in_use: (), // used for stack canary
 }
 
 impl<'file> ProcessedElf<'file> {
@@ -81,12 +81,14 @@ impl<'file> ProcessedElf<'file> {
         let live_functions = extract_live_functions(&elf)?;
 
         let (defmt_table, defmt_locations) = extract_defmt_info(elf_bytes)?;
+        let vector_table = extract_vector_table(&elf)?;
 
         Ok(Self {
             defmt_table,
             defmt_locations,
             elf,
             live_functions,
+            vector_table,
         })
     }
     //     fn symbol_map(&self) -> SymbolMap {
@@ -155,7 +157,7 @@ fn extract_live_functions<'file>(elf: &ElfFile<'file>) -> anyhow::Result<HashSet
     Ok(live_functions)
 }
 
-pub(crate) fn extract_vector_table(elf: &ElfFile) -> anyhow::Result<VectorTable> {
+fn extract_vector_table(elf: &ElfFile) -> anyhow::Result<VectorTable> {
     let section = elf
         .section_by_name(".vector_table")
         .ok_or_else(|| anyhow!("`.vector_table` section is missing"))?;

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -12,7 +12,7 @@ use arrayref::array_ref;
 use defmt_decoder::Table;
 use object::{read::File as ElfFile, Object, ObjectSection, ObjectSymbol, SymbolSection};
 
-use crate::VectorTable;
+use crate::cortexm;
 
 pub(crate) fn notmain() -> anyhow::Result<i32> {
     // - parse CL arguments
@@ -70,7 +70,7 @@ pub(crate) struct ProcessedElf<'file> {
 
     // // currently extracted via `for` loop over sections
     pub(crate) debug_frame: &'file [u8], // gimli one (not bytes)
-    pub(crate) vector_table: VectorTable, // processed one (not bytes)
+    pub(crate) vector_table: cortexm::VectorTable, // processed one (not bytes)
                                          // highest_ram_address_in_use: (), // used for stack canary
 }
 
@@ -159,7 +159,7 @@ fn extract_live_functions<'file>(elf: &ElfFile<'file>) -> anyhow::Result<HashSet
     Ok(live_functions)
 }
 
-fn extract_vector_table(elf: &ElfFile) -> anyhow::Result<VectorTable> {
+fn extract_vector_table(elf: &ElfFile) -> anyhow::Result<cortexm::VectorTable> {
     let section = elf
         .section_by_name(".vector_table")
         .ok_or_else(|| anyhow!("`.vector_table` section is missing"))?;
@@ -180,7 +180,7 @@ fn extract_vector_table(elf: &ElfFile) -> anyhow::Result<VectorTable> {
     if let (Some(initial_stack_pointer), Some(reset), Some(_third), Some(hard_fault)) =
         (words.next(), words.next(), words.next(), words.next())
     {
-        Ok(VectorTable {
+        Ok(cortexm::VectorTable {
             location: start,
             initial_stack_pointer,
             reset,

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashSet},
     env, fs,
+    ops::Deref,
     path::Path,
 };
 
@@ -86,6 +87,14 @@ impl<'file> ProcessedElf<'file> {
     //     fn symbol_map(&self) -> SymbolMap {
     //         self.elf.symbol_map()
     //     }
+}
+
+impl<'elf> Deref for ProcessedElf<'elf> {
+    type Target = ElfFile<'elf>;
+
+    fn deref(&self) -> &ElfFile<'elf> {
+        &self.elf
+    }
 }
 
 fn extract_defmt_info(elf_bytes: &[u8]) -> Result<Option<Table>, anyhow::Error> {

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,0 +1,74 @@
+use object::{read::File as ElfFile, Object, ObjectSection};
+use probe_rs::config::{MemoryRegion, RamRegion};
+use std::convert::TryInto;
+
+use crate::elf::ProcessedElf;
+
+pub(crate) struct TargetInfo {
+    pub(crate) target: probe_rs::Target,
+    pub(crate) active_ram_region: Option<RamRegion>,
+    pub(crate) highest_ram_addr_in_use: Option<u32>, // todo maybe merge
+}
+
+impl TargetInfo {
+    pub(crate) fn new(chip: &str, elf: &ProcessedElf) -> anyhow::Result<Self> {
+        let target = probe_rs::config::registry::get_target_by_name(chip)?;
+        let active_ram_region =
+            extract_active_ram_region(&target, elf.vector_table.initial_stack_pointer);
+        let highest_ram_addr_in_use =
+            extract_highest_ram_addr_in_use(elf, active_ram_region.as_ref())?;
+        Ok(Self {
+            target,
+            active_ram_region,
+            highest_ram_addr_in_use,
+        })
+    }
+}
+
+fn extract_active_ram_region(target: &probe_rs::Target, initial_sp: u32) -> Option<RamRegion> {
+    target
+        .memory_map
+        .iter()
+        .filter_map(|region| match region {
+            MemoryRegion::Ram(region) => {
+                // NOTE stack is full descending; meaning the stack pointer can be
+                // `ORIGIN(RAM) + LENGTH(RAM)`
+                let range = region.range.start..=region.range.end;
+                if range.contains(&initial_sp) {
+                    Some(region)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .next()
+        .cloned()
+}
+
+fn extract_highest_ram_addr_in_use(
+    elf: &ElfFile,
+    active_ram_region: Option<&RamRegion>,
+) -> anyhow::Result<Option<u32>> {
+    let mut highest_ram_addr_in_use = None;
+    for sect in elf.sections() {
+        // If this section resides in RAM, track the highest RAM address in use.
+        if let Some(ram) = active_ram_region {
+            if sect.size() != 0 {
+                let last_addr = sect.address() + sect.size() - 1;
+                let last_addr = last_addr.try_into()?;
+                if ram.range.contains(&last_addr) {
+                    log::debug!(
+                        "section `{}` is in RAM at 0x{:08X}-0x{:08X}",
+                        sect.name().unwrap_or("<unknown>"),
+                        sect.address(),
+                        last_addr,
+                    );
+                    highest_ram_addr_in_use = highest_ram_addr_in_use.max(Some(last_addr));
+                }
+            }
+        }
+    }
+
+    Ok(highest_ram_addr_in_use)
+}

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,4 +1,4 @@
-use object::{Object, ObjectSection};
+use object::{Object, ObjectSection as _};
 use probe_rs::config::{MemoryRegion, RamRegion};
 use std::convert::TryInto;
 

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,8 +1,8 @@
-use object::{read::File as ElfFile, Object, ObjectSection};
+use object::{Object, ObjectSection};
 use probe_rs::config::{MemoryRegion, RamRegion};
 use std::convert::TryInto;
 
-use crate::elf::ProcessedElf;
+use crate::elf::Elf;
 
 pub(crate) struct TargetInfo {
     pub(crate) target: probe_rs::Target,
@@ -11,7 +11,7 @@ pub(crate) struct TargetInfo {
 }
 
 impl TargetInfo {
-    pub(crate) fn new(chip: &str, elf: &ProcessedElf) -> anyhow::Result<Self> {
+    pub(crate) fn new(chip: &str, elf: &Elf) -> anyhow::Result<Self> {
         let target = probe_rs::config::registry::get_target_by_name(chip)?;
         let active_ram_region =
             extract_active_ram_region(&target, elf.vector_table.initial_stack_pointer);
@@ -47,7 +47,7 @@ fn extract_active_ram_region(target: &probe_rs::Target, initial_sp: u32) -> Opti
 }
 
 fn extract_highest_ram_addr_in_use(
-    elf: &ElfFile,
+    elf: &object::read::File,
     active_ram_region: Option<&RamRegion>,
 ) -> anyhow::Result<Option<u32>> {
     let mut highest_ram_addr_in_use = None;

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -7,21 +7,21 @@ use crate::elf::Elf;
 pub(crate) struct TargetInfo {
     pub(crate) probe_target: probe_rs::Target,
     pub(crate) active_ram_region: Option<RamRegion>,
-    pub(crate) highest_ram_addr_in_use: Option<u32>, // todo maybe merge
+    pub(crate) highest_ram_address_in_use: Option<u32>, // todo maybe merge
 }
 
 impl TargetInfo {
     pub(crate) fn new(chip: &str, elf: &Elf) -> anyhow::Result<Self> {
-        let target = probe_rs::config::registry::get_target_by_name(chip)?;
+        let probe_target = probe_rs::config::registry::get_target_by_name(chip)?;
         let active_ram_region =
-            extract_active_ram_region(&target, elf.vector_table.initial_stack_pointer);
-        let highest_ram_addr_in_use =
-            extract_highest_ram_addr_in_use(elf, active_ram_region.as_ref());
+            extract_active_ram_region(&probe_target, elf.vector_table.initial_stack_pointer);
+        let highest_ram_address_in_use =
+            extract_highest_ram_address_in_use(elf, active_ram_region.as_ref());
 
         Ok(Self {
-            probe_target: target,
+            probe_target,
             active_ram_region,
-            highest_ram_addr_in_use,
+            highest_ram_address_in_use,
         })
     }
 }
@@ -50,7 +50,7 @@ fn extract_active_ram_region(
         .cloned()
 }
 
-fn extract_highest_ram_addr_in_use(
+fn extract_highest_ram_address_in_use(
     elf: &object::read::File,
     active_ram_region: Option<&RamRegion>,
 ) -> Option<u32> {


### PR DESCRIPTION
what the PR title says. I ran the ELFs from PR #218 and they print the expected output.

This is the most non-trivial change that may have changed semantics
- before we were extracting *two* RAM regions from the probe-rs registry. The "first one" (returned by the iterator) and the "one that contains the initial stack pointer (initial_sp)". we installed the canary on "the first one" but only if it contained the initial_sp
- now, we only extract one RAM region, the one that contains initial_sp, and install the canary there

I think this still does the same, in practice, but not 100% sure.