### PR TITLE
target_info: print ram region again

### DIFF
--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -41,6 +41,11 @@ fn extract_active_ram_region(
                 // `ORIGIN(RAM) + LENGTH(RAM)`
                 let inclusive_range = ram_region.range.start..=ram_region.range.end;
                 if inclusive_range.contains(&initial_stack_pointer) {
+                    log::debug!(
+                        "RAM region: 0x{:08X}-0x{:08X}",
+                        ram_region.range.start,
+                        ram_region.range.end - 1
+                    );
                     Some(ram_region)
                 } else {
                     None


### PR DESCRIPTION
after the [snapshot test](https://github.com/knurling-rs/probe-run/pull/218/files) rebase I noticed we're not printing the RAM region anymore. I'm not sure if I'm misremembering that that was on purpose. If I *am* misremembering, this PR fixes that. If I'm not misremembering, it leaves a paper trail. 