### PR TITLE
Enable deactivated tests for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +300,17 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "gimli"
@@ -635,6 +666,7 @@ dependencies = [
  "colored",
  "defmt-decoder",
  "difference",
+ "dirs",
  "either",
  "gimli 0.24.0",
  "git-version",
@@ -705,6 +737,25 @@ name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
 
 [[package]]
 name = "rstest"
@@ -1011,6 +1062,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ signal-hook = "0.3"
 structopt = "0.3"
 
 [dev-dependencies]
+dirs = "3.0"
 insta = "1.7"
 os_pipe = "0.9"
 pretty_assertions = "0.7"

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -97,7 +97,7 @@ mod tests {
         let expected = Path {
             registry_prefix,
             crate_name_version: "cortex-m-rt-0.6.13",
-            path: &PathBuf::new().join("src").join("lib.rs"),
+            path: &PathBuf::from("src").join("lib.rs"),
         };
 
         assert_eq!(expected, path);

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -104,22 +104,31 @@ mod tests {
         let home = dirs::home_dir().unwrap();
         let home = home.to_str().unwrap();
 
-        let input = format!("{}/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs", home);
-        let input = StdPath::new(&input);
+        let input = PathBuf::from(home)
+            .join(".cargo")
+            .join("registry")
+            .join("src")
+            .join("github.com-1ecc6299db9ec823")
+            .join("cortex-m-rt-0.6.13")
+            .join("src")
+            .join("lib.rs");
+        let path = Path::from_std_path(&input).unwrap();
 
-        let registry_prefix = format!("{}/.cargo/registry/src/github.com-1ecc6299db9ec823/", home);
+        let registry_prefix = PathBuf::from(home)
+            .join(".cargo")
+            .join("registry")
+            .join("src")
+            .join("github.com-1ecc6299db9ec823");
 
-        let path = Path::from_std_path(input).unwrap();
-        dbg!(&path);
         let expected = Path {
-            registry_prefix: PathBuf::from(&registry_prefix),
+            registry_prefix,
             crate_name_version: "cortex-m-rt-0.6.13",
-            path: StdPath::new("src/lib.rs"),
+            path: &PathBuf::new().join("src").join("lib.rs"),
         };
 
         assert_eq!(expected, path);
 
-        let expected_str = "[cortex-m-rt-0.6.13]\\src/lib.rs";
+        let expected_str = "[cortex-m-rt-0.6.13]\\src\\lib.rs";
         let formatted_str = path.format_short();
 
         assert_eq!(expected_str, formatted_str);

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -69,15 +69,17 @@ impl<'p> Path<'p> {
     }
 }
 
-#[cfg(all(test, unix))]
+// #[cfg(all(test, unix, windows))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn end_to_end() {
         let input = StdPath::new(
-        "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs",
-    );
+            "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs",
+        );
 
         let path = Path::from_std_path(input).unwrap();
         let expected = Path {
@@ -91,6 +93,33 @@ mod tests {
         assert_eq!(expected, path);
 
         let expected_str = "[cortex-m-rt-0.6.13]/src/lib.rs";
+        let formatted_str = path.format_short();
+
+        assert_eq!(expected_str, formatted_str);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn end_to_end_windows() {
+        let home = dirs::home_dir().unwrap();
+        let home = home.to_str().unwrap();
+
+        let input = format!("{}/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs", home);
+        let input = StdPath::new(&input);
+
+        let registry_prefix = format!("{}/.cargo/registry/src/github.com-1ecc6299db9ec823/", home);
+
+        let path = Path::from_std_path(input).unwrap();
+        dbg!(&path);
+        let expected = Path {
+            registry_prefix: PathBuf::from(&registry_prefix),
+            crate_name_version: "cortex-m-rt-0.6.13",
+            path: StdPath::new("src/lib.rs"),
+        };
+
+        assert_eq!(expected, path);
+
+        let expected_str = "[cortex-m-rt-0.6.13]\\src/lib.rs";
         let formatted_str = path.format_short();
 
         assert_eq!(expected_str, formatted_str);

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -88,25 +88,23 @@ mod tests {
             .join("lib.rs");
         let path = Path::from_std_path(&input).unwrap();
 
-        let registry_prefix = PathBuf::from(home)
-            .join(".cargo")
-            .join("registry")
-            .join("src")
-            .join("github.com-1ecc6299db9ec823");
-
         let expected = Path {
-            registry_prefix,
+            registry_prefix: PathBuf::from(home)
+                .join(".cargo")
+                .join("registry")
+                .join("src")
+                .join("github.com-1ecc6299db9ec823"),
             crate_name_version: "cortex-m-rt-0.6.13",
             path: &PathBuf::from("src").join("lib.rs"),
         };
 
         assert_eq!(expected, path);
 
-        let expected_str = PathBuf::from("[cortex-m-rt-0.6.13]")
+        let expected = PathBuf::from("[cortex-m-rt-0.6.13]")
             .join("src")
             .join("lib.rs");
         let formatted_str = path.format_short();
 
-        assert_eq!(expected_str.to_string_lossy(), formatted_str);
+        assert_eq!(expected.to_string_lossy(), formatted_str);
     }
 }

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -102,7 +102,9 @@ mod tests {
 
         assert_eq!(expected, path);
 
-        let expected_str = PathBuf::from("[cortex-m-rt-0.6.13]").join("src").join("lib.rs");
+        let expected_str = PathBuf::from("[cortex-m-rt-0.6.13]")
+            .join("src")
+            .join("lib.rs");
         let formatted_str = path.format_short();
 
         assert_eq!(expected_str.to_string_lossy(), formatted_str);

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -74,33 +74,8 @@ impl<'p> Path<'p> {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn end_to_end() {
-        let input = StdPath::new(
-            "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs",
-        );
-
-        let path = Path::from_std_path(input).unwrap();
-        let expected = Path {
-            registry_prefix: PathBuf::from(
-                "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/",
-            ),
-            crate_name_version: "cortex-m-rt-0.6.13",
-            path: StdPath::new("src/lib.rs"),
-        };
-
-        assert_eq!(expected, path);
-
-        let expected_str = "[cortex-m-rt-0.6.13]/src/lib.rs";
-        let formatted_str = path.format_short();
-
-        assert_eq!(expected_str, formatted_str);
-    }
-
-    #[cfg(not(unix))]
-    #[test]
-    fn end_to_end_windows() {
         let home = dirs::home_dir().unwrap();
         let home = home.to_str().unwrap();
 
@@ -128,9 +103,9 @@ mod tests {
 
         assert_eq!(expected, path);
 
-        let expected_str = "[cortex-m-rt-0.6.13]\\src\\lib.rs";
+        let expected_str = PathBuf::from("[cortex-m-rt-0.6.13]").join("src").join("lib.rs");
         let formatted_str = path.format_short();
 
-        assert_eq!(expected_str, formatted_str);
+        assert_eq!(expected_str.to_string_lossy(), formatted_str);
     }
 }

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -69,7 +69,6 @@ impl<'p> Path<'p> {
     }
 }
 
-// #[cfg(all(test, unix, windows))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/dep/mod.rs
+++ b/src/dep/mod.rs
@@ -71,8 +71,7 @@ mod tests {
         let home = dirs::home_dir().unwrap();
         let home = home.to_str().unwrap();
 
-        let cratesio = PathBuf::new()
-            .join(home)
+        let cratesio = PathBuf::from(home)
             .join(".cargo")
             .join("registry")
             .join("src")
@@ -85,8 +84,7 @@ mod tests {
             Path::Cratesio(_)
         ));
 
-        let rustc = PathBuf::new()
-            .join(home)
+        let rustc = PathBuf::from(home)
             .join("rustc")
             .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53")
             .join("library")
@@ -98,8 +96,7 @@ mod tests {
             Path::Rustc(_)
         ));
 
-        let rust_std = PathBuf::new()
-            .join(home)
+        let rust_std = PathBuf::from(home)
             .join(".rustup")
             .join("toolchains")
             .join("stable-x86_64-unknown-linux-gnu")
@@ -117,7 +114,7 @@ mod tests {
             Path::RustStd(_)
         ));
 
-        let local = PathBuf::new().join("src").join("lib.rs");
+        let local = PathBuf::from("src").join("lib.rs");
         assert!(matches!(
             Path::from_std_path(local.as_path()),
             Path::Verbatim(_)

--- a/src/dep/mod.rs
+++ b/src/dep/mod.rs
@@ -79,10 +79,7 @@ mod tests {
             .join("cortex-m-rt-0.6.13")
             .join("src")
             .join("lib.rs");
-        assert!(matches!(
-            Path::from_std_path(cratesio.as_path()),
-            Path::Cratesio(_)
-        ));
+        assert!(matches!(Path::from_std_path(&cratesio), Path::Cratesio(_)));
 
         let rustc = PathBuf::from(home)
             .join("rustc")
@@ -91,10 +88,7 @@ mod tests {
             .join("core")
             .join("src")
             .join("panicking.rs");
-        assert!(matches!(
-            Path::from_std_path(rustc.as_path()),
-            Path::Rustc(_)
-        ));
+        assert!(matches!(Path::from_std_path(&rustc), Path::Rustc(_)));
 
         let rust_std = PathBuf::from(home)
             .join(".rustup")
@@ -109,15 +103,9 @@ mod tests {
             .join("src")
             .join("sync")
             .join("atomic.rs");
-        assert!(matches!(
-            Path::from_std_path(rust_std.as_path()),
-            Path::RustStd(_)
-        ));
+        assert!(matches!(Path::from_std_path(&rust_std), Path::RustStd(_)));
 
         let local = PathBuf::from("src").join("lib.rs");
-        assert!(matches!(
-            Path::from_std_path(local.as_path()),
-            Path::Verbatim(_)
-        ));
+        assert!(matches!(Path::from_std_path(&local), Path::Verbatim(_)));
     }
 }

--- a/src/dep/mod.rs
+++ b/src/dep/mod.rs
@@ -60,26 +60,67 @@ fn get_component_normal(component: Component) -> Option<&OsStr> {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
     fn from_std_path_returns_correct_variant() {
-        let cratesio = StdPath::new(
-            "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs",
-        );
-        let rustc = StdPath::new(
-            "/rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/panicking.rs",
-        );
-        let rust_std = StdPath::new(
-            "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/sync/atomic.rs",
-        );
-        let local = StdPath::new("src/lib.rs");
+        let home = dirs::home_dir().unwrap();
+        let home = home.to_str().unwrap();
 
-        assert!(matches!(Path::from_std_path(cratesio), Path::Cratesio(_)));
-        assert!(matches!(Path::from_std_path(rustc), Path::Rustc(_)));
-        assert!(matches!(Path::from_std_path(rust_std), Path::RustStd(_)));
-        assert!(matches!(Path::from_std_path(local), Path::Verbatim(_)));
+        let cratesio = PathBuf::new()
+            .join(home)
+            .join(".cargo")
+            .join("registry")
+            .join("src")
+            .join("github.com-1ecc6299db9ec823")
+            .join("cortex-m-rt-0.6.13")
+            .join("src")
+            .join("lib.rs");
+        assert!(matches!(
+            Path::from_std_path(cratesio.as_path()),
+            Path::Cratesio(_)
+        ));
+
+        let rustc = PathBuf::new()
+            .join(home)
+            .join("rustc")
+            .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53")
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("panicking.rs");
+        assert!(matches!(
+            Path::from_std_path(rustc.as_path()),
+            Path::Rustc(_)
+        ));
+
+        let rust_std = PathBuf::new()
+            .join(home)
+            .join(".rustup")
+            .join("toolchains")
+            .join("stable-x86_64-unknown-linux-gnu")
+            .join("lib")
+            .join("rustlib")
+            .join("src")
+            .join("rust")
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("sync")
+            .join("atomic.rs");
+        assert!(matches!(
+            Path::from_std_path(rust_std.as_path()),
+            Path::RustStd(_)
+        ));
+
+        let local = PathBuf::new().join("src").join("lib.rs");
+        assert!(matches!(
+            Path::from_std_path(local.as_path()),
+            Path::Verbatim(_)
+        ));
     }
 }

--- a/src/dep/rust_repo.rs
+++ b/src/dep/rust_repo.rs
@@ -103,14 +103,14 @@ mod tests {
 
         assert_eq!(expected, rust_repo_path);
 
-        let expected_str = PathBuf::from("library")
+        let expected = PathBuf::from("library")
             .join("core")
             .join("src")
             .join("sync")
             .join("atomic.rs");
         let formatted_str = rust_repo_path.format();
 
-        assert_eq!(expected_str.to_string_lossy(), formatted_str);
+        assert_eq!(expected.to_string_lossy(), formatted_str);
     }
 
     #[test]

--- a/src/dep/rust_repo.rs
+++ b/src/dep/rust_repo.rs
@@ -95,7 +95,7 @@ mod tests {
             .join("sync")
             .join("atomic.rs");
 
-        let rust_repo_path = Path::from_std_path(path.as_path());
+        let rust_repo_path = Path::from_std_path(&path);
         let expected = Path::One52(One52Path {
             library: "library",
             crate_name: "core",

--- a/src/dep/rust_repo.rs
+++ b/src/dep/rust_repo.rs
@@ -88,8 +88,7 @@ mod tests {
 
     #[test]
     fn v1_52_path() {
-        let path = PathBuf::new()
-            .join("library")
+        let path = PathBuf::from("library")
             .join("core")
             .join("src")
             .join("sync")
@@ -104,8 +103,7 @@ mod tests {
 
         assert_eq!(expected, rust_repo_path);
 
-        let expected_str = PathBuf::new()
-            .join("library")
+        let expected_str = PathBuf::from("library")
             .join("core")
             .join("src")
             .join("sync")

--- a/src/dep/rust_repo.rs
+++ b/src/dep/rust_repo.rs
@@ -80,15 +80,22 @@ impl<'p> One52Path<'p> {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
     fn v1_52_path() {
-        let path = StdPath::new("library/core/src/sync/atomic.rs");
+        let path = PathBuf::new()
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("sync")
+            .join("atomic.rs");
 
-        let rust_repo_path = Path::from_std_path(path);
+        let rust_repo_path = Path::from_std_path(path.as_path());
         let expected = Path::One52(One52Path {
             library: "library",
             crate_name: "core",
@@ -97,10 +104,15 @@ mod tests {
 
         assert_eq!(expected, rust_repo_path);
 
-        let expected_str = "library/core/src/sync/atomic.rs";
+        let expected_str = PathBuf::new()
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("sync")
+            .join("atomic.rs");
         let formatted_str = rust_repo_path.format();
 
-        assert_eq!(expected_str, formatted_str);
+        assert_eq!(expected_str.to_string_lossy(), formatted_str);
     }
 
     #[test]

--- a/src/dep/rust_std.rs
+++ b/src/dep/rust_std.rs
@@ -80,21 +80,38 @@ impl<'p> Path<'p> {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
-    use std::path::Path as StdPath;
-
     use pretty_assertions::assert_eq;
 
     use super::*;
 
     #[test]
     fn end_to_end() {
-        let input = StdPath::new("/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/sync/atomic.rs");
+        let home = dirs::home_dir().unwrap();
+        let home = home.to_str().unwrap();
 
-        let path = Path::from_std_path(input).unwrap();
+        let input = PathBuf::new()
+            .join(home)
+            .join(".rustup")
+            .join("toolchains")
+            .join("stable-x86_64-unknown-linux-gnu")
+            .join("lib")
+            .join("rustlib")
+            .join("src")
+            .join("rust")
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("sync")
+            .join("atomic.rs");
+
+        let path = Path::from_std_path(input.as_path()).unwrap();
+
+        let src_path = PathBuf::from("src").join("sync").join("atomic.rs");
+
         let expected = Path {
-            rustup_prefix: PathBuf::from("/home/user/.rustup/toolchains"),
+            rustup_prefix: PathBuf::from(home).join(".rustup").join("toolchains"),
             toolchain: Toolchain::One52(toolchain::One52 {
                 channel: toolchain::Channel::Stable,
                 host: "x86_64-unknown-linux-gnu",
@@ -103,15 +120,20 @@ mod tests {
             rust_repo_path: rust_repo::Path::One52(rust_repo::One52Path {
                 library: "library",
                 crate_name: "core",
-                path: StdPath::new("src/sync/atomic.rs"),
+                path: src_path.as_path(),
             }),
         };
 
         assert_eq!(expected, path);
 
-        let expected_str = "[stable]/library/core/src/sync/atomic.rs";
+        let expected_str = PathBuf::from("[stable]")
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("sync")
+            .join("atomic.rs");
         let formatted_str = path.format_short();
 
-        assert_eq!(expected_str, formatted_str);
+        assert_eq!(expected_str.to_string_lossy(), formatted_str);
     }
 }

--- a/src/dep/rust_std.rs
+++ b/src/dep/rust_std.rs
@@ -125,7 +125,7 @@ mod tests {
 
         assert_eq!(expected, path);
 
-        let expected_str = PathBuf::from("[stable]")
+        let expected = PathBuf::from("[stable]")
             .join("library")
             .join("core")
             .join("src")
@@ -133,6 +133,6 @@ mod tests {
             .join("atomic.rs");
         let formatted_str = path.format_short();
 
-        assert_eq!(expected_str.to_string_lossy(), formatted_str);
+        assert_eq!(expected.to_string_lossy(), formatted_str);
     }
 }

--- a/src/dep/rust_std.rs
+++ b/src/dep/rust_std.rs
@@ -91,8 +91,7 @@ mod tests {
         let home = dirs::home_dir().unwrap();
         let home = home.to_str().unwrap();
 
-        let input = PathBuf::new()
-            .join(home)
+        let input = PathBuf::from(home)
             .join(".rustup")
             .join("toolchains")
             .join("stable-x86_64-unknown-linux-gnu")
@@ -106,7 +105,7 @@ mod tests {
             .join("sync")
             .join("atomic.rs");
 
-        let path = Path::from_std_path(input.as_path()).unwrap();
+        let path = Path::from_std_path(&input).unwrap();
 
         let src_path = PathBuf::from("src").join("sync").join("atomic.rs");
 
@@ -120,7 +119,7 @@ mod tests {
             rust_repo_path: rust_repo::Path::One52(rust_repo::One52Path {
                 library: "library",
                 crate_name: "core",
-                path: src_path.as_path(),
+                path: &src_path,
             }),
         };
 

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -95,13 +95,13 @@ mod tests {
 
         assert_eq!(expected, path);
 
-        let expected_str = PathBuf::from("[rust]")
+        let expected = PathBuf::from("[rust]")
             .join("library")
             .join("core")
             .join("src")
             .join("panicking.rs");
         let formatted_str = path.format_short();
 
-        assert_eq!(expected_str.to_string_lossy(), formatted_str);
+        assert_eq!(expected.to_string_lossy(), formatted_str);
     }
 }

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -72,7 +72,7 @@ mod tests {
 
         let input = PathBuf::new()
             .join(home)
-            .join("rustc")  // important part
+            .join("rustc")
             .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53")
             .join("library")
             .join("core")
@@ -81,7 +81,7 @@ mod tests {
 
         let rustc_prefix = PathBuf::new()
             .join(home)
-            .join("rustc")  // important part
+            .join("rustc")
             .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53");
 
         let path = Path::from_std_path(&input).unwrap();

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -70,8 +70,7 @@ mod tests {
         let home = dirs::home_dir().unwrap();
         let home = home.to_str().unwrap();
 
-        let input = PathBuf::new()
-            .join(home)
+        let input = PathBuf::from(home)
             .join("rustc")
             .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53")
             .join("library")
@@ -79,8 +78,7 @@ mod tests {
             .join("src")
             .join("panicking.rs");
 
-        let rustc_prefix = PathBuf::new()
-            .join(home)
+        let rustc_prefix = PathBuf::from(home)
             .join("rustc")
             .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53");
 

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -72,20 +72,25 @@ mod tests {
         );
 
         let path = Path::from_std_path(input).unwrap();
+        let expected_path = PathBuf::from("src").join("panicking.rs");
         let expected = Path {
             rustc_prefix: PathBuf::from("/rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53"),
             rust_repo_path: rust_repo::Path::One52(rust_repo::One52Path {
                 library: "library",
                 crate_name: "core",
-                path: StdPath::new("src/panicking.rs"),
+                path: expected_path.as_path(),
             }),
         };
 
         assert_eq!(expected, path);
 
-        let expected_str = "[rust]/library/core/src/panicking.rs";
+        let expected_str = PathBuf::from("[rust]")
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("panicking.rs");
         let formatted_str = path.format_short();
 
-        assert_eq!(expected_str, formatted_str);
+        assert_eq!(expected_str.to_string_lossy(), formatted_str);
     }
 }

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -61,20 +61,33 @@ impl<'p> Path<'p> {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn end_to_end() {
-        let input = StdPath::new(
-            "/rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/panicking.rs",
-        );
+        let home = dirs::home_dir().unwrap();
+        let home = home.to_str().unwrap();
 
-        let path = Path::from_std_path(input).unwrap();
+        let input = PathBuf::new()
+            .join(home)
+            .join("rustc")  // important part
+            .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53")
+            .join("library")
+            .join("core")
+            .join("src")
+            .join("panicking.rs");
+
+        let rustc_prefix = PathBuf::new()
+            .join(home)
+            .join("rustc")  // important part
+            .join("9bc8c42bb2f19e745a63f3445f1ac248fb015e53");
+
+        let path = Path::from_std_path(&input).unwrap();
         let expected_path = PathBuf::from("src").join("panicking.rs");
         let expected = Path {
-            rustc_prefix: PathBuf::from("/rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53"),
+            rustc_prefix,
             rust_repo_path: rust_repo::Path::One52(rust_repo::One52Path {
                 library: "library",
                 crate_name: "core",

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -89,7 +89,7 @@ mod tests {
             rust_repo_path: rust_repo::Path::One52(rust_repo::One52Path {
                 library: "library",
                 crate_name: "core",
-                path: expected_path.as_path(),
+                path: &expected_path,
             }),
         };
 


### PR DESCRIPTION
This PR enables a number of tests to run on Windows, which were previously only tested on Unix-like systems.

* use [dirs](https://github.com/soc/dirs-rs) crate to obtain the OS specific home directory for some of the tests
* refactor building of paths by using [`PathBuf::join`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join)