### PR TITLE
Print troubleshooting information on "probe not found" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,17 +201,38 @@ $ cargo run --bin hello --force-backtrace
 
 ## Troubleshooting
 
-### `probe-run --list-probes` says "No devices were found."
+### "Error: no probe was found."
 
-Apart from a faulty connection between your computer and the target device, this could be caused by several things:
+First, check your data cable:
+
+- make sure that it is connected to the right port on your development board
+- make sure that you are using a **data** cable– some cables are built for charging only! When in doubt, try using a different cable.
+
+If this doesn't resolve the issue, try the following:
 
 #### [Linux only] udev rules haven't been set
 
-In order for `probe-run` to find the device you'd like to run your code on, your system needs permission to access the device as a non-root user.
+Check if your device shows up in `lsusb`:
+
+```console
+$ lsusb
+Bus 001 Device 008: ID 1366:1015 SEGGER J-Link
+# if your device shows up like this ^^^^^^^^, skip to the next troubleshooting section
+```
+
+**If it doesn't show up**, you need to give your system permission to access the device as a non-root user so that `probe-run` can find your device.
 
 In order to grant these permissions, you'll need to add a new set of udev rules.
 
 To learn how to do this for the nRF52840 Development Kit, check out the [installation instructions](https://embedded-trainings.ferrous-systems.com/installation.html?highlight=udev#linux-only-usb) in our embedded training materials.
+
+afterwards, your device should show up in `probe-run --list-probes` similar to this:
+
+```console
+$ probe-run --list-probes
+The following devices were found:
+[0]: J-Link (J-Link) (VID: 1366, PID: 1015, Serial: <redacted>, JLink)
+```
 
 #### No external or on-board debugger present
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ Check if your device shows up in `lsusb`:
 ```console
 $ lsusb
 Bus 001 Device 008: ID 1366:1015 SEGGER J-Link
-# if your device shows up like this ^^^^^^^^, skip to the next troubleshooting section
 ```
+
+If your device shows up like in the example, skip to the next troubleshooting section
 
 **If it doesn't show up**, you need to give your system permission to access the device as a non-root user so that `probe-run` can find your device.
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 > Runs embedded programs just like native ones
 
-`probe-run` is a custom Cargo runner that transparently runs Rust firmware on a
-remote device.
+`probe-run` is a custom Cargo runner that transparently runs Rust firmware on an embedded device.
 
-`probe-run` is powered by [`probe-rs`] and thus supports as many devices and probes as
+`probe-run` is powered by [`probe-rs`] and thus supports all the devices and probes supported by
 `probe-rs` does.
 
 [`probe-rs`]: https://probe.rs/

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -5,6 +5,8 @@ use probe_rs::{DebugProbeInfo, Probe};
 
 use crate::cli;
 
+const NO_PROBE_FOUND_ERR: &str = "no probe was found.";
+
 pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     let all_probes = Probe::list_all();
     let filtered_probes = if let Some(probe_opt) = opts.probe.as_deref() {
@@ -15,7 +17,7 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     };
 
     if filtered_probes.is_empty() {
-        bail!("no probe was found")
+        bail!("{}", NO_PROBE_FOUND_ERR)
     }
 
     log::debug!("found {} probes", filtered_probes.len());
@@ -37,13 +39,13 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
 
 pub(crate) fn print(probes: &[DebugProbeInfo]) {
     if !probes.is_empty() {
-        println!("The following devices were found:");
+        println!("the following probes were found:");
         probes
             .iter()
             .enumerate()
             .for_each(|(num, link)| println!("[{}]: {:?}", num, link));
     } else {
-        println!("No devices were found.");
+        println!("Error: {}", NO_PROBE_FOUND_ERR);
     }
 }
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -5,7 +5,9 @@ use probe_rs::{DebugProbeInfo, Probe};
 
 use crate::cli;
 
-const NO_PROBE_FOUND_ERR: &str = "no probe was found.";
+const NO_PROBE_FOUND_ERR: &str = "no probe was found.\n
+Common reasons for this are faulty cables or missing permissions.
+For detailed instructions, visit: https://github.com/knurling-rs/probe-run/tree/2f138c3#troubleshooting";
 
 pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     let all_probes = Probe::list_all();


### PR DESCRIPTION
resolves https://github.com/knurling-rs/probe-run/issues/239 .