### PR TITLE
feat: add help message for JtagNoDeviceConnected

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,13 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
             if e.to_string().contains("JtagNoDeviceConnected") {
                 eprintln!("Info: Jtag cannot find a connected device.");
                 eprintln!("Help:");
-                eprintln!("    Try using probe-run with option `--connect-under-reset`");
-                eprintln!("    Or if using cargo:");
+                eprintln!("    Check that the debugger is connected to the chip, if so");
+                eprintln!("    try using probe-run with option `--connect-under-reset`");
+                eprintln!("    or, if using cargo:");
                 eprintln!("        cargo run -- --connect-under-reset");
-                eprintln!("    This error comes from the program currently in the chip and");
-                eprintln!("    using `--connect-under-reset` is only a workaround.\n");
+                eprintln!("    If using this flag fixed your issue, this error might");
+                eprintln!("    come from the program currently in the chip and using");
+                eprintln!("    `--connect-under-reset` is only a workaround.\n");
             }
         }
         probe_attach?

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,8 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     } else {
         let probe_attach = probe.attach(probe_target);
         if let Err(probe_rs::Error::Probe(ProbeSpecific(e))) = &probe_attach {
+            // FIXME Using `to_string().contains(...)` is a workaround as the concrete type
+            // of `e` is not public and therefore does not allow downcasting.
             if e.to_string().contains("JtagNoDeviceConnected") {
                 eprintln!("Info: Jtag cannot find a connected device.");
                 eprintln!("Help:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,8 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
         probe.attach_under_reset(probe_target)?
     } else {
         let probe_attach = probe.attach(probe_target);
-        if let Err(probe_rs::Error::Probe(ProbeSpecific(ref e))) = probe_attach {
-            if format!("{}", e).contains("JtagNoDeviceConnected") {
+        if let Err(probe_rs::Error::Probe(ProbeSpecific(e))) = &probe_attach {
+            if e.to_string().contains("JtagNoDeviceConnected") {
                 eprintln!("Info: Jtag cannot find a connected device.");
                 eprintln!("Help:");
                 eprintln!("    Try using probe-run with option `--connect-under-reset`");


### PR DESCRIPTION
Hello!

I had the `JtagNoDeviceConnected` error and did not know what to do, and someone in the Rust Embedded matrix channel told me that it happens to a lot of people. So maybe `probe-run` could print some help in this case. This is what this PR does.

```
% cargo run --bin=blinky
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `/home/*****/Development/probe-run/target/debug/probe-run --chip STM32F407VGTx target/thumbv7em-none-eabi/debug/blinky`
Info: Jtag cannot find a connected device.
Help:
    Try using probe-run with option `--connect-under-reset`
    Or if using cargo:
        cargo run -- --connect-under-reset
    This error comes from the program currently in the chip and
    using `--connect-under-reset` is only a workaround.

Error: An error specific to a probe type occured

Caused by:
    Command failed with status JtagNoDeviceConnected
```

This PR is just to show the idea, I can refactor it as needed.

In the matrix channel was also discussed the possibility to:

- enable the flag automatically when the error occurs, which can be done while printing a warning, and/or
- add a link to an explanation of the reason why this error occurs and how to avoid it in the future

Refactoring of this PR would enable to add help for the user about more various kinds of errors.