### PR TITLE
Add support for measuring the program's stack usage

### DIFF
--- a/src/canary.rs
+++ b/src/canary.rs
@@ -54,7 +54,7 @@ impl Canary {
 
         // Decide if and where to place the stack canary.
 
-        let stack_range = match &target_info.stack_range {
+        let stack_info = match &target_info.stack_info {
             Some(range) => range,
             None => {
                 log::debug!("couldn't find valid stack range, not placing stack canary");
@@ -67,7 +67,7 @@ impl Canary {
             return Ok(None);
         }
 
-        let stack_available = stack_range.end() - stack_range.start() - 1;
+        let stack_available = stack_info.range.end() - stack_info.range.start() - 1;
 
         let size = if measure_stack {
             // When measuring stack consumption, we have to color the whole stack.
@@ -82,8 +82,8 @@ impl Canary {
         log::debug!(
             "{} bytes of stack available ({:#010X} ..= {:#010X}), using {} byte canary",
             stack_available,
-            stack_range.start(),
-            stack_range.end(),
+            stack_info.range.start(),
+            stack_info.range.end(),
             size,
         );
 
@@ -95,7 +95,7 @@ impl Canary {
                 size_kb
             );
         }
-        let address = *stack_range.start();
+        let address = *stack_info.range.start();
         let canary = vec![CANARY_VALUE; size];
         core.write_8(address, &canary)?;
 
@@ -103,7 +103,7 @@ impl Canary {
             address,
             size,
             stack_available,
-            data_below_stack: target_info.data_below_stack,
+            data_below_stack: stack_info.data_below_stack,
             measure_stack,
         }))
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,10 @@ pub(crate) struct Opts {
     #[structopt(long)]
     pub(crate) shorten_paths: bool,
 
+    /// Whether to measure the program's stack consumption.
+    #[structopt(long)]
+    pub(crate) measure_stack: bool,
+
     /// Arguments passed after the ELF file path are discarded
     #[structopt(name = "REST")]
     _rest: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,9 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     }
 
     let canary = Canary::install(&mut sess, &target_info, elf, opts.measure_stack)?;
+    if opts.measure_stack && canary.is_none() {
+        bail!("failed to set up stack measurement");
+    }
     start_program(&mut sess, elf)?;
 
     let sess = Arc::new(Mutex::new(sess));

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,10 +41,10 @@ fn main() -> anyhow::Result<()> {
 
 fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> anyhow::Result<i32> {
     if !elf_path.exists() {
-        return Err(anyhow!(
+        bail!(
             "can't find ELF file at `{}`; are you sure you got the right path?",
             elf_path.display()
-        ));
+        );
     }
 
     let elf_bytes = fs::read(elf_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
         log::info!("success!");
     }
 
-    let canary = Canary::install(&mut sess, &target_info, elf)?;
+    let canary = Canary::install(&mut sess, &target_info, elf, opts.measure_stack)?;
     start_program(&mut sess, elf)?;
 
     let sess = Arc::new(Mutex::new(sess));

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -1,6 +1,6 @@
 use object::{Object, ObjectSection as _};
 use probe_rs::config::{MemoryRegion, RamRegion};
-use std::convert::TryInto;
+use std::{convert::TryInto, ops::RangeInclusive};
 
 use crate::elf::Elf;
 
@@ -8,8 +8,9 @@ pub(crate) struct TargetInfo {
     pub(crate) probe_target: probe_rs::Target,
     /// RAM region that contains the call stack
     pub(crate) active_ram_region: Option<RamRegion>,
-    /// Only `Some` if static variables are located in the `active_ram_region`
-    pub(crate) highest_static_var_address: Option<u32>,
+    /// Valid values of the stack pointer (that don't collide with other data).
+    pub(crate) stack_range: Option<RangeInclusive<u32>>,
+    pub(crate) data_below_stack: bool,
 }
 
 impl TargetInfo {
@@ -17,13 +18,22 @@ impl TargetInfo {
         let probe_target = probe_rs::config::get_target_by_name(chip)?;
         let active_ram_region =
             extract_active_ram_region(&probe_target, elf.vector_table.initial_stack_pointer);
-        let highest_static_var_address =
-            extract_highest_static_var_address(elf, active_ram_region.as_ref());
+        let stack_range = extract_stack_range(
+            elf,
+            active_ram_region.as_ref(),
+            elf.vector_table.initial_stack_pointer,
+        );
+
+        let data_below_stack = match (&active_ram_region, &stack_range) {
+            (Some(ram), Some(stack)) => *stack.start() > ram.range.start,
+            _ => false,
+        };
 
         Ok(Self {
             probe_target,
             active_ram_region,
-            highest_static_var_address,
+            stack_range,
+            data_below_stack,
         })
     }
 }
@@ -56,36 +66,54 @@ fn extract_active_ram_region(
         .cloned()
 }
 
-fn extract_highest_static_var_address(
+fn extract_stack_range(
     elf: &object::read::File,
     active_ram_region: Option<&RamRegion>,
-) -> Option<u32> {
+    initial_stack_pointer: u32,
+) -> Option<RangeInclusive<u32>> {
     let active_ram_region = active_ram_region?;
 
-    elf.sections()
-        .filter_map(|section| {
-            let size = section.size();
-            if size == 0 {
+    // SP points one past the end of the stack.
+    let mut stack_range = active_ram_region.range.start..=initial_stack_pointer - 1;
+
+    for section in elf.sections() {
+        let size: u32 = section.size().try_into().expect("expected 32-bit ELF");
+        if size == 0 {
+            continue;
+        }
+
+        let lowest_address: u32 = section.address().try_into().expect("expected 32-bit ELF");
+        let highest_address = (lowest_address + size - 1)
+            .try_into()
+            .expect("expected 32-bit ELF");
+        let section_range = lowest_address..=highest_address;
+        let name = section.name().unwrap_or("<unknown>");
+
+        if active_ram_region.range.contains(&highest_address) {
+            log::debug!(
+                "section `{}` is in RAM at {:#010X} ..= {:#010X}",
+                name,
+                lowest_address,
+                highest_address,
+            );
+
+            if section_range.contains(&(initial_stack_pointer - 1)) {
+                log::debug!(
+                    "initial SP is in section `{}`, cannot determine valid stack range",
+                    name
+                );
                 return None;
             }
 
-            let lowest_address = section.address();
-            let highest_address = (lowest_address + size - 1)
-                .try_into()
-                .expect("expected 32-bit ELF");
-
-            if active_ram_region.range.contains(&highest_address) {
-                log::debug!(
-                    "section `{}` is in RAM at {:#010X} ..= {:#010X}",
-                    section.name().unwrap_or("<unknown>"),
-                    lowest_address,
-                    highest_address,
-                );
-
-                Some(highest_address)
-            } else {
-                None
+            if initial_stack_pointer > lowest_address && *stack_range.start() <= highest_address {
+                stack_range = highest_address + 1..=initial_stack_pointer;
             }
-        })
-        .max()
+        }
+    }
+    log::debug!(
+        "valid SP range: {:#010X} ..= {:#010X}",
+        stack_range.start(),
+        stack_range.end(),
+    );
+    Some(stack_range)
 }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -83,9 +83,7 @@ fn extract_stack_range(
         }
 
         let lowest_address: u32 = section.address().try_into().expect("expected 32-bit ELF");
-        let highest_address = (lowest_address + size - 1)
-            .try_into()
-            .expect("expected 32-bit ELF");
+        let highest_address = lowest_address + size - 1;
         let section_range = lowest_address..=highest_address;
         let name = section.name().unwrap_or("<unknown>");
 


### PR DESCRIPTION
This cleans up the stack canary code a bit, and adds a `--measure-stack` command that will paint the entire available stack region with a known bit pattern, and then report how much of the available stack space was used by the program.

Closes https://github.com/knurling-rs/probe-run/issues/188

```
(HOST) INFO  flashing program (7.03 KiB)
(HOST) INFO  success!
(HOST) INFO  painting 261063 bytes of RAM for stack usage estimation
────────────────────────────────────────────────────────────────────────────────
0 INFO  recurse(times=10)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
1 INFO  recurse(times=9)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
2 INFO  recurse(times=8)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
3 INFO  recurse(times=7)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
4 INFO  recurse(times=6)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
5 INFO  recurse(times=5)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
6 INFO  recurse(times=4)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
7 INFO  recurse(times=3)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
8 INFO  recurse(times=2)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
9 INFO  recurse(times=1)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
10 INFO  recurse(times=0)
└─ overflow::recurse @ /home/jonas/dev/probe-test/src/bin/overflow.rs:13
────────────────────────────────────────────────────────────────────────────────
(HOST) INFO  reading 261063 bytes of RAM for stack usage estimation
(HOST) INFO  program has used at least 23240/261063 bytes of stack space
(HOST) INFO  device halted without error
```