### PR TITLE
Split "set rtt to blocking-mode" into function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -169,13 +169,13 @@ fn set_rtt_to_blocking(
     let rtt_buffer_address = rtt_buffer_address + OFFSET;
 
     // read flags
-    let rtt_control_block = &mut [0];
-    core.read_32(rtt_buffer_address, rtt_control_block)?;
+    let channel_flags = &mut [0];
+    core.read_32(rtt_buffer_address, channel_flags)?;
     // modify flags to blocking
     const BLOCK_IF_FULL: u32 = 2;
-    let b = rtt_control_block[0] | BLOCK_IF_FULL;
+    let modified_channel_flags = channel_flags[0] | BLOCK_IF_FULL;
     // write flags back
-    core.write_word_32(rtt_buffer_address, b)?;
+    core.write_word_32(rtt_buffer_address, modified_channel_flags)?;
 
     // clear the breakpoint we set before
     core.clear_hw_breakpoint(main_fn_address)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,8 +164,8 @@ fn set_rtt_to_blocking(
     core.wait_for_core_halted(Duration::from_secs(5))?;
 
     const OFFSET: u32 = 44;
-    const FLAG: u32 = 2; // BLOCK_IF_FULL
-    core.write_word_32(rtt_buffer_address + OFFSET, FLAG)?;
+    const BLOCK_IF_FULL: u32 = 2;
+    core.write_word_32(rtt_buffer_address + OFFSET, BLOCK_IF_FULL)?;
     core.clear_hw_breakpoint(main_fn_address)?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,17 +164,17 @@ fn set_rtt_to_blocking(
     core.run()?;
     core.wait_for_core_halted(Duration::from_secs(5))?;
 
-    // calculate address of rtt control block
+    // calculate address of up-channel-flags inside the rtt control block
     const OFFSET: u32 = 44;
     let rtt_buffer_address = rtt_buffer_address + OFFSET;
 
-    // read control block
+    // read flags
     let rtt_control_block = &mut [0];
     core.read_32(rtt_buffer_address, rtt_control_block)?;
-    // modify it to blocking
+    // modify flags to blocking
     const BLOCK_IF_FULL: u32 = 2;
     let b = rtt_control_block[0] | BLOCK_IF_FULL;
-    // write it back
+    // write flags back
     core.write_word_32(rtt_buffer_address, b)?;
 
     // clear the breakpoint we set before

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use colored::Colorize as _;
 use defmt_decoder::Locations;
 use probe_rs::{
     flashing::{self, Format},
+    Core,
     DebugProbeError::ProbeSpecific,
     MemoryInterface as _, Session,
 };
@@ -130,7 +131,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     Ok(outcome.into())
 }
 
-fn start_program(sess: &mut Session, elf: &Elf) -> Result<(), anyhow::Error> {
+fn start_program(sess: &mut Session, elf: &Elf) -> anyhow::Result<()> {
     let mut core = sess.core(0)?;
 
     log::debug!("starting device");
@@ -142,20 +143,30 @@ fn start_program(sess: &mut Session, elf: &Elf) -> Result<(), anyhow::Error> {
         }
     }
 
-    if let Some(rtt) = elf.rtt_buffer_address() {
-        let main = elf.main_fn_address();
-        core.set_hw_breakpoint(main)?;
-        core.run()?;
-        core.wait_for_core_halted(Duration::from_secs(5))?;
-
-        const OFFSET: u32 = 44;
-        const FLAG: u32 = 2; // BLOCK_IF_FULL
-        core.write_word_32(rtt + OFFSET, FLAG)?;
-        core.clear_hw_breakpoint(main)?;
+    if let Some(rtt_buffer_address) = elf.rtt_buffer_address() {
+        set_rtt_to_blocking(&mut core, elf.main_fn_address(), rtt_buffer_address)?
     }
 
     core.set_hw_breakpoint(cortexm::clear_thumb_bit(elf.vector_table.hard_fault))?;
     core.run()?;
+
+    Ok(())
+}
+
+/// Set rtt to blocking mode
+fn set_rtt_to_blocking(
+    core: &mut Core,
+    main_fn_address: u32,
+    rtt_buffer_address: u32,
+) -> anyhow::Result<()> {
+    core.set_hw_breakpoint(main_fn_address)?;
+    core.run()?;
+    core.wait_for_core_halted(Duration::from_secs(5))?;
+
+    const OFFSET: u32 = 44;
+    const FLAG: u32 = 2; // BLOCK_IF_FULL
+    core.write_word_32(rtt_buffer_address + OFFSET, FLAG)?;
+    core.clear_hw_breakpoint(main_fn_address)?;
 
     Ok(())
 }
@@ -165,7 +176,7 @@ fn extract_and_print_logs(
     sess: &Arc<Mutex<Session>>,
     opts: &cli::Opts,
     current_dir: &Path,
-) -> Result<bool, anyhow::Error> {
+) -> anyhow::Result<bool> {
     let exit = Arc::new(AtomicBool::new(false));
     let sig_id = signal_hook::flag::register(signal::SIGINT, exit.clone())?;
 
@@ -261,7 +272,7 @@ fn decode_and_print_defmt_logs(
     locations: Option<&Locations>,
     current_dir: &Path,
     opts: &cli::Opts,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     loop {
         match table.decode(buffer) {
             Ok((frame, consumed)) => {


### PR DESCRIPTION
Firstly this shortens the `fn start_program`,
secondly it makes the "what" of this block of code more apparent.