### PR TITLE
fix ci on nightly

### DIFF
--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -46,11 +46,8 @@ pub(crate) fn subroutine_eq(addr1: u32, addr2: u32) -> bool {
 /// The contents of the vector table
 #[derive(Debug)]
 pub(crate) struct VectorTable {
-    pub(crate) location: u32,
     // entry 0
     pub(crate) initial_stack_pointer: u32,
-    // entry 1: Reset handler
-    pub(crate) reset: u32,
     // entry 3: HardFault handler
     pub(crate) hard_fault: u32,
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -128,7 +128,7 @@ fn extract_vector_table(elf: &ObjectFile) -> anyhow::Result<cortexm::VectorTable
         .section_by_name(".vector_table")
         .ok_or_else(|| anyhow!("`.vector_table` section is missing"))?;
 
-    let start = section.address().try_into()?;
+    let start = section.address();
     let size = section.size();
 
     if size % 4 != 0 || start % 4 != 0 {
@@ -140,13 +140,11 @@ fn extract_vector_table(elf: &ObjectFile) -> anyhow::Result<cortexm::VectorTable
         .chunks_exact(4)
         .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()));
 
-    if let (Some(initial_stack_pointer), Some(reset), Some(_third), Some(hard_fault)) =
+    if let (Some(initial_stack_pointer), Some(_reset), Some(_third), Some(hard_fault)) =
         (words.next(), words.next(), words.next(), words.next())
     {
         Ok(cortexm::VectorTable {
-            location: start,
             initial_stack_pointer,
-            reset,
             hard_fault,
         })
     } else {


### PR DESCRIPTION
dead_code lint changed and it now warns on unused struct fields that are in derive(Debug) structs