### PR TITLE
set blocking mode to 0b10 (BLOCK_IF_FULL)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,8 +180,9 @@ fn set_rtt_to_blocking(
     let channel_flags = &mut [0];
     core.read_32(rtt_buffer_address, channel_flags)?;
     // modify flags to blocking
-    const BLOCK_IF_FULL: u32 = 2;
-    let modified_channel_flags = channel_flags[0] | BLOCK_IF_FULL;
+    const MODE_MASK: u32 = 0b11;
+    const MODE_BLOCK_IF_FULL: u32 = 0b10;
+    let modified_channel_flags = (channel_flags[0] & !MODE_MASK) | MODE_BLOCK_IF_FULL;
     // write flags back
     core.write_word_32(rtt_buffer_address, modified_channel_flags)?;
 


### PR DESCRIPTION
the previous version (after PR #257) was setting the blocking mode (first 2 bits of the flags field) to 0b11 (0b01
is what defmt-rtt uses by default) which is not a valid mode