### PR TITLE
Report flashing size using probe-rs's FlashProgress system.

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -3,8 +3,7 @@ use std::{collections::HashSet, convert::TryInto, env, ops::Deref};
 use anyhow::{anyhow, bail};
 use defmt_decoder::{Locations, Table};
 use object::{
-    read::File as ObjectFile, Object as _, ObjectSection as _, ObjectSegment as _,
-    ObjectSymbol as _, SymbolSection,
+    read::File as ObjectFile, Object as _, ObjectSection as _, ObjectSymbol as _, SymbolSection,
 };
 
 use crate::cortexm;
@@ -54,13 +53,6 @@ impl<'file> Elf<'file> {
 
     pub(crate) fn rtt_buffer_address(&self) -> Option<u32> {
         self.symbols.rtt_buffer_address
-    }
-
-    /// Returns the size of the part of the program allocated in Flash
-    pub(crate) fn program_flash_size(&self) -> u64 {
-        // `segments` iterates only over *loadable* segments,
-        // which are the segments that will be loaded to Flash by probe-rs
-        self.elf.segments().map(|segment| segment.size()).sum()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,13 +88,27 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
                     let pages = flash_layout.pages();
                     let num_pages = pages.len();
                     let num_bytes: u64 = pages.iter().map(|x| x.size() as u64).sum();
-                    log::info!("flashing program ({} pages / {:.02} KiB)", num_pages, num_bytes as f64 / 1024.0);
+                    log::info!(
+                        "flashing program ({} pages / {:.02} KiB)",
+                        num_pages,
+                        num_bytes as f64 / 1024.0
+                    );
                 }
+                // A sector has been erased. Sectors (usually) contain multiple pages.
                 flashing::ProgressEvent::SectorErased { size, time } => {
-                    log::debug!("Erased sector of size {} bytes in {} ms", size, time.as_millis());
+                    log::debug!(
+                        "Erased sector of size {} bytes in {} ms",
+                        size,
+                        time.as_millis()
+                    );
                 }
+                // A page has been programmed.
                 flashing::ProgressEvent::PageProgrammed { size, time } => {
-                    log::debug!("Programmed page of size {} bytes in {} ms", size, time.as_millis());
+                    log::debug!(
+                        "Programmed page of size {} bytes in {} ms",
+                        size,
+                        time.as_millis()
+                    );
                 }
                 _ => {
                     // Ignore other events


### PR DESCRIPTION
We get an Initialized object at the start, and then one message per sector erase and one message per block write.