### PR TITLE
Include program counter value in backtrace when -v is passed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,12 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,7 +701,6 @@ dependencies = [
  "colored",
  "defmt-decoder",
  "dirs",
- "either",
  "gimli",
  "git-version",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ addr2line = { version = "0.15", default-features = false, features = [
 anyhow = "1"
 colored = "2"
 defmt-decoder = { version = "=0.3.0", features = ["unstable"] }
-either = "1.6"
 gimli = { version = "0.24", default-features = false }
 git-version = "0.3"
 log = "0.4"

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -33,6 +33,7 @@ pub(crate) struct Settings<'p> {
     pub(crate) panic_present: bool,
     pub(crate) backtrace_limit: u32,
     pub(crate) shorten_paths: bool,
+    pub(crate) include_addresses: bool,
 }
 
 /// (virtually) unwinds the target's program and prints its backtrace

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,9 +47,9 @@ pub(crate) struct Opts {
     #[structopt(long)]
     pub(crate) connect_under_reset: bool,
 
-    /// Enable more verbose logging.
+    /// Enable more verbose output.
     #[structopt(short, long, parse(from_occurrences))]
-    verbose: u32,
+    pub(crate) verbose: u32,
 
     /// Prints version information
     #[structopt(short = "V", long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
         backtrace: (&opts.backtrace).into(),
         panic_present,
         shorten_paths: opts.shorten_paths,
+        include_addresses: opts.verbose > 0,
     };
 
     let mut outcome = backtrace::print(

--- a/tests/snapshots/test__panic_verbose.snap
+++ b/tests/snapshots/test__panic_verbose.snap
@@ -15,13 +15,13 @@ expression: run_result.output
 (HOST) INFO  flashing program (6.57 KiB)
 (HOST) INFO  success!
 (HOST) DEBUG 261062 bytes of stack available (0x20000000 ..= 0x2003FBC7), using 1024 byte canary
-(HOST) TRACE setting up canary took 0.012s (83.61 KiB/s)
+(HOST) TRACE setting up canary took 0.014s (71.21 KiB/s)
 (HOST) DEBUG starting device
 (HOST) DEBUG Successfully attached RTT
 ────────────────────────────────────────────────────────────────────────────────
 ERROR panicked at 'explicit panic'
 ────────────────────────────────────────────────────────────────────────────────
-(HOST) TRACE reading canary took 0.011s (92.16 KiB/s)
+(HOST) TRACE reading canary took 0.014s (72.39 KiB/s)
 (HOST) DEBUG stack canary intact
 (HOST) DEBUG LR=0xFFFFFFF9 PC=0x000015B0
 (HOST) DEBUG LR=0x000001C9 PC=0x000008DE
@@ -37,26 +37,35 @@ ERROR panicked at 'explicit panic'
 (HOST) DEBUG LR=0x0000018B PC=0x000001DC
 (HOST) DEBUG update_cfa: CFA changed Some(2003fbc0) -> 2003fbc8
 (HOST) DEBUG LR=0xFFFFFFFF PC=0x0000018A
+(HOST) TRACE demangle Ok("_ZN3lib6inline5__udf17h4878bf20408765ceE") (language=Some(DwLang(1C))) -> Ok("lib::inline::__udf")
+(HOST) TRACE demangle Ok("__udf") (language=Some(DwLang(1C))) -> Ok("__udf")
+(HOST) TRACE demangle Ok("_ZN8cortex_m3asm3udf17h4c0f9f15c9bfd7bfE") (language=Some(DwLang(1C))) -> Ok("cortex_m::asm::udf")
+(HOST) TRACE demangle Ok("_defmt_panic") (language=Some(DwLang(1C))) -> Ok("_defmt_panic")
+(HOST) TRACE demangle Ok("_ZN5defmt6export5panic17h3fabd155b5d3f035E") (language=Some(DwLang(1C))) -> Ok("defmt::export::panic")
+(HOST) TRACE demangle Ok("_ZN5panic18__cortex_m_rt_main17hdf4a9d08e66ae2a1E") (language=Some(DwLang(1C))) -> Ok("panic::__cortex_m_rt_main")
+(HOST) TRACE demangle Ok("main") (language=Some(DwLang(1C))) -> Ok("main")
+(HOST) TRACE demangle Ok("ResetTrampoline") (language=Some(DwLang(1C))) -> Ok("ResetTrampoline")
+(HOST) TRACE demangle Ok("Reset") (language=Some(DwLang(1C))) -> Ok("Reset")
 stack backtrace:
-   0: HardFaultTrampoline
+   0: 0x000015b0 @ HardFaultTrampoline
       <exception entry>
-   1: lib::inline::__udf
+   1: 0x000008de @ lib::inline::__udf
         at ./asm/inline.rs:172:5
-   2: __udf
+   2: 0x000008de @ __udf
         at ./asm/lib.rs:49:17
-   3: cortex_m::asm::udf
+   3: 0x000001c8 @ cortex_m::asm::udf
         at [cortex-m-0.7.3]/src/asm.rs:43:5
-   4: _defmt_panic
+   4: 0x000001d2 @ _defmt_panic
         at /tmp/app/src/lib.rs:11:5
-   5: defmt::export::panic
+   5: 0x000001be @ defmt::export::panic
         at /home/japaric/.cargo/git/checkouts/defmt-52fbd7917982cfac/e021e7d/src/export.rs:266:14
-   6: panic::__cortex_m_rt_main
+   6: 0x000001be @ panic::__cortex_m_rt_main
         at /tmp/app/src/bin/panic.rs:8:5
-   7: main
+   7: 0x00000194 @ main
         at /tmp/app/src/bin/panic.rs:6:1
-   8: ResetTrampoline
+   8: 0x000001dc @ ResetTrampoline
         at [cortex-m-rt-0.6.14]/src/lib.rs:547:26
-   9: Reset
+   9: 0x0000018a @ Reset
         at [cortex-m-rt-0.6.14]/src/lib.rs:550:13
 (HOST) ERROR the program panicked
 


### PR DESCRIPTION
This can help when debugging.

```
stack backtrace:
   0: 0x000015b0 @ HardFaultTrampoline
      <exception entry>
   1: 0x000008de @ lib::inline::__udf
        at ./asm/inline.rs:172:5
   2: 0x000008de @ __udf
        at ./asm/lib.rs:49:17
   3: 0x000001c8 @ cortex_m::asm::udf
        at [cortex-m-0.7.3]/src/asm.rs:43:5
   4: 0x000001d2 @ _defmt_panic
        at /tmp/app/src/lib.rs:11:5
   5: 0x000001be @ defmt::export::panic
        at /home/japaric/.cargo/git/checkouts/defmt-52fbd7917982cfac/e021e7d/src/export.rs:266:14
   6: 0x000001be @ panic::__cortex_m_rt_main
        at /tmp/app/src/bin/panic.rs:8:5
   7: 0x00000194 @ main
        at /tmp/app/src/bin/panic.rs:6:1
   8: 0x000001dc @ ResetTrampoline
        at [cortex-m-rt-0.6.14]/src/lib.rs:547:26
   9: 0x0000018a @ Reset
        at [cortex-m-rt-0.6.14]/src/lib.rs:550:13
```