### PR TITLE
Update probe-rs, probe-rs-rtt to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-- [#]
+- [#285]: Update `probe-rs` and `probe-rs-rtt` to `0.12`
 
+[#285]: https://github.com/knurling-rs/probe-run/pull/285
 
 ## [v0.3.0] - 2021-11-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli",
+ "gimli 0.24.0",
  "object 0.24.0",
  "rustc-demangle",
 ]
@@ -91,9 +91,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.19.5"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
@@ -208,7 +208,7 @@ dependencies = [
  "colored",
  "defmt-parser",
  "difference",
- "gimli",
+ "gimli 0.24.0",
  "log",
  "object 0.25.3",
  "ryu",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "getrandom"
@@ -317,6 +317,16 @@ name = "gimli"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -570,6 +580,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "probe-rs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769c3160e006e16220a7d505ac6051e43655cb1bbeee027a5fe1bac9ef64d5c8"
+checksum = "232e7f2912aba17bef48f84f9d90bfc9e6c1d8c90959fcf1451ccb3a68819ee7"
 dependencies = [
  "anyhow",
  "base64",
@@ -649,14 +668,14 @@ dependencies = [
  "bitfield",
  "bitvec",
  "enum-primitive-derive",
- "gimli",
+ "gimli 0.26.1",
  "hidapi",
  "ihex",
  "jaylink",
  "jep106",
  "log",
  "num-traits",
- "object 0.25.3",
+ "object 0.27.1",
  "once_cell",
  "probe-rs-target",
  "rusb",
@@ -671,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-rtt"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de940be8e1c8f3af3927bcfeccdb02f05556f5d221028a56a0b6c89898b82804"
+checksum = "17a9f49ddd5fa2f079961debbea5f93e4fc168bf89223a0407aa9de60eed8d51"
 dependencies = [
  "log",
  "probe-rs",
@@ -683,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-target"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd2aebcc973030c9ff5041c9dc4f44a66a7f382376a378c76d38570a0765ebb"
+checksum = "0f9610234697e695947df2f7b0cd71d4e4e2fe2fea13df90bdc44bb65e0ef16f"
 dependencies = [
  "base64",
  "jep106",
@@ -701,7 +720,7 @@ dependencies = [
  "colored",
  "defmt-decoder",
  "dirs",
- "gimli",
+ "gimli 0.24.0",
  "git-version",
  "insta",
  "log",
@@ -767,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "redox_syscall"
@@ -992,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "svg"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1206d132b55a9c93e12b7e6f9044a27b563a8dea3a39d9bc1764d613a7dd3fa"
+checksum = "e72d8b19ab05827afefcca66bf47040c1e66a0901eb814784c77d4ec118bd309"
 
 [[package]]
 name = "syn"
@@ -1130,9 +1149,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ gimli = { version = "0.24", default-features = false }
 git-version = "0.3"
 log = "0.4"
 object = { version = "0.24", default-features = false }
-probe-rs = "0.11"
-probe-rs-rtt = "0.11"
+probe-rs = "0.12"
+probe-rs-rtt = "0.12"
 signal-hook = "0.3"
 structopt = "0.3"
 


### PR DESCRIPTION
Probe-rs 0.12 was just released. This updates the dependency and fixes the breaking changes.

Tested the binary using an STM32 Nucleo devboard.