### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,8 +10,8 @@ checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli 0.26.1",
- "object 0.27.1",
+ "gimli",
+ "object",
  "rustc-demangle",
 ]
 
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-decoder"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326d55129bb42c2459efc5c4c890e772bb1c0ae219db9bab379765643ebc39d9"
+checksum = "a7d5765366c461413e5b2966b89f14bbdb3f5d785fd03f1cfe8261fcfcac6844"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -208,9 +208,9 @@ dependencies = [
  "colored",
  "defmt-parser",
  "difference",
- "gimli 0.24.0",
+ "gimli",
  "log",
- "object 0.25.3",
+ "object",
  "ryu",
  "serde",
  "serde_json",
@@ -310,16 +310,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "gimli"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
-dependencies = [
- "fallible-iterator",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -563,15 +553,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
@@ -660,14 +641,14 @@ dependencies = [
  "bitfield",
  "bitvec",
  "enum-primitive-derive",
- "gimli 0.26.1",
+ "gimli",
  "hidapi",
  "ihex",
  "jaylink",
  "jep106",
  "log",
  "num-traits",
- "object 0.27.1",
+ "object",
  "once_cell",
  "probe-rs-target",
  "rusb",
@@ -705,19 +686,19 @@ dependencies = [
 
 [[package]]
 name = "probe-run"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "addr2line",
  "anyhow",
  "colored",
  "defmt-decoder",
  "dirs",
- "gimli 0.26.1",
+ "gimli",
  "git-version",
  "insta",
  "log",
  "nix",
- "object 0.27.1",
+ "object",
  "os_pipe",
  "pretty_assertions",
  "probe-rs",

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use crate::{backtrace::Outcome, canary::Canary, elf::Elf, target_info::TargetInf
 const TIMEOUT: Duration = Duration::from_secs(1);
 
 fn main() -> anyhow::Result<()> {
+    #[allow(clippy::redundant_closure)]
     cli::handle_arguments().map(|code| process::exit(code))
 }
 


### PR DESCRIPTION
During updating `defmt-decoder` to `0.3.1` it was forgotten to update `Cargo.lock` as well (by running `cargo check`). This happens now.