### PR TITLE
Fix and refactor `fn extract_stack_info`

### DIFF
--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -97,7 +97,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
                     name
                 );
                 return None;
-            } else if is_superset(&(stack_start..=stack_end), &section_range) {
+            } else if section_range.contains(&stack_start) {
                 stack_start = section_range.end() + 1;
             }
         }
@@ -109,31 +109,4 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
         data_below_stack: *stack_range.start() > ram_range.start,
         range: stack_range,
     })
-}
-
-fn is_superset(superset: &RangeInclusive<u32>, subset: &RangeInclusive<u32>) -> bool {
-    subset.start() >= superset.start() && subset.end() <= superset.end()
-}
-
-#[cfg(test)]
-mod tests {
-    use rstest::rstest;
-
-    use super::*;
-
-    #[rstest]
-    #[case(0..=10, 0..=10, true)]
-    #[case(0..=10, 1..=9, true)]
-    #[case(0..=10, 0..=5, true)]
-    #[case(0..=10, 5..=10, true)]
-    #[case(0..=10, 0..=11, false)]
-    #[case(0..=10, 5..=11, false)]
-    fn should_extract_hash_from_description(
-        #[case] superset: RangeInclusive<u32>,
-        #[case] subset: RangeInclusive<u32>,
-        #[case] expected: bool,
-    ) {
-        let is_superset = is_superset(&superset, &subset);
-        assert_eq!(is_superset, expected)
-    }
 }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -74,8 +74,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
     let initial_stack_pointer = elf.vector_table.initial_stack_pointer;
 
     // SP points one past the end of the stack.
-    let stack_end = initial_stack_pointer - 1;
-    let mut stack_range = ram_range.start..=stack_end;
+    let mut stack_range = ram_range.start..=initial_stack_pointer - 1;
 
     for section in elf.sections() {
         let size: u32 = section.size().try_into().expect("expected 32-bit ELF");
@@ -91,7 +90,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
         if ram_range.contains(section_range.end()) {
             log::debug!("section `{}` is in RAM at {:#010X?}", name, section_range);
 
-            if section_range.contains(&stack_end) {
+            if section_range.contains(stack_range.end()) {
                 log::debug!(
                     "initial SP is in section `{}`, cannot determine valid stack range",
                     name

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -102,7 +102,7 @@ fn extract_stack_info(
             }
 
             if initial_stack_pointer > lowest_address && *stack_range.start() <= highest_address {
-                stack_range = highest_address + 1..=initial_stack_pointer;
+                stack_range = highest_address + 1..=initial_stack_pointer - 1;
             }
         }
     }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -97,7 +97,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
                     name
                 );
                 return None;
-            } else if stack_start <= *section_range.end() {
+            } else if section_range.contains(&stack_start) {
                 stack_start = section_range.end() + 1;
             }
         }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -69,6 +69,10 @@ fn extract_stack_info(
     active_ram_region: Option<&RamRegion>,
     initial_stack_pointer: u32,
 ) -> Option<StackInfo> {
+    // How does it work?
+    // - the upper end of the stack is the initial SP, minus one
+    // - the lower end of the stack is the highest address any section in the elf file uses, plus one
+
     let ram_range = &active_ram_region?.range;
 
     // SP points one past the end of the stack.
@@ -99,11 +103,7 @@ fn extract_stack_info(
             }
         }
     }
-    log::debug!(
-        "valid SP range: {:#010X} ..= {:#010X}",
-        stack_range.start(),
-        stack_range.end(),
-    );
+    log::debug!("valid SP range: {:#010X?}", stack_range);
     Some(StackInfo {
         data_below_stack: *stack_range.start() > ram_range.start,
         range: stack_range,

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -105,10 +105,7 @@ fn extract_stack_info(elf: &Elf, ram_region: Option<&RamRegion>) -> Option<Stack
 }
 
 fn is_superset(superset: &RangeInclusive<u32>, subset: &RangeInclusive<u32>) -> bool {
-    subset.start() >= superset.start()
-        && subset.start() <= superset.end()
-        && subset.end() <= superset.end()
-        && subset.end() >= superset.start()
+    subset.start() >= superset.start() && subset.end() <= superset.end()
 }
 
 #[cfg(test)]

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -85,24 +85,19 @@ fn extract_stack_info(
         let section_range = lowest_address..=highest_address;
         let name = section.name().unwrap_or("<unknown>");
 
-        if active_ram_region.range.contains(&highest_address) {
-            log::debug!(
-                "section `{}` is in RAM at {:#010X} ..= {:#010X}",
-                name,
-                lowest_address,
-                highest_address,
-            );
+        if active_ram_region.range.contains(section_range.end()) {
+            log::debug!("section `{}` is in RAM at {:#010X?}", name, section_range);
 
-            if section_range.contains(&(initial_stack_pointer - 1)) {
+            if section_range.contains(stack_range.end()) {
                 log::debug!(
                     "initial SP is in section `{}`, cannot determine valid stack range",
                     name
                 );
                 return None;
-            }
-
-            if initial_stack_pointer > lowest_address && *stack_range.start() <= highest_address {
-                stack_range = highest_address + 1..=initial_stack_pointer - 1;
+            } else if stack_range.end() >= section_range.start()
+                && stack_range.start() <= section_range.end()
+            {
+                stack_range = section_range.end() + 1..=*stack_range.end();
             }
         }
     }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -97,7 +97,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
                     name
                 );
                 return None;
-            } else if section_range.contains(&stack_start) {
+            } else if stack_start <= *section_range.end() {
                 stack_start = section_range.end() + 1;
             }
         }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -69,10 +69,10 @@ fn extract_stack_info(
     active_ram_region: Option<&RamRegion>,
     initial_stack_pointer: u32,
 ) -> Option<StackInfo> {
-    let active_ram_region = active_ram_region?;
+    let ram_range = &active_ram_region?.range;
 
     // SP points one past the end of the stack.
-    let mut stack_range = active_ram_region.range.start..=initial_stack_pointer - 1;
+    let mut stack_range = ram_range.start..=initial_stack_pointer - 1;
 
     for section in elf.sections() {
         let size: u32 = section.size().try_into().expect("expected 32-bit ELF");
@@ -85,7 +85,7 @@ fn extract_stack_info(
         let section_range = lowest_address..=highest_address;
         let name = section.name().unwrap_or("<unknown>");
 
-        if active_ram_region.range.contains(section_range.end()) {
+        if ram_range.contains(section_range.end()) {
             log::debug!("section `{}` is in RAM at {:#010X?}", name, section_range);
 
             if section_range.contains(stack_range.end()) {
@@ -107,7 +107,7 @@ fn extract_stack_info(
         stack_range.end(),
     );
     Some(StackInfo {
-        data_below_stack: *stack_range.start() > active_ram_region.range.start,
+        data_below_stack: *stack_range.start() > ram_range.start,
         range: stack_range,
     })
 }


### PR DESCRIPTION

- Fix the `stack_range` end.
    The high end of the stack is always `initial_stack_pointer - 1`.
- Use range methods instead of variables.
- Simplify accessing range of ram region
- Introduce `fn is_superset` for two ranges.
    I am aware that in our concrete scenario we don't need all four, but
    only two conditions (as it was before), since we are checking
    `subset.contains(superset.end())` before. But I have added them for
    completeness.
- Document what `fn extract_stack_info` does
- Simplify arguments of `fn extract_stack_info`
