### PR TITLE
Add way to pass chip description file

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,8 @@ pub(crate) struct Opts {
     #[structopt(long, required_unless_one(&["list-chips", "list-probes", "version"]), env = "PROBE_RUN_CHIP")]
     chip: Option<String>,
 
-    #[structopt(name = "chip description file path", long = "chip-description-path")]
+    /// Path to chip description file, in YAML format.
+    #[structopt(long)]
     pub(crate) chip_description_path: Option<PathBuf>,
 
     /// The probe to use (eg. `VID:PID`, `VID:PID:Serial`, or just `Serial`).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,9 @@ pub(crate) struct Opts {
     #[structopt(long, required_unless_one(&["list-chips", "list-probes", "version"]), env = "PROBE_RUN_CHIP")]
     chip: Option<String>,
 
+    #[structopt(name = "chip description file path", long = "chip-description-path")]
+    pub(crate) chip_description_path: Option<PathBuf>,
+
     /// The probe to use (eg. `VID:PID`, `VID:PID:Serial`, or just `Serial`).
     #[structopt(long, env = "PROBE_RUN_PROBE")]
     pub(crate) probe: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     let elf_bytes = fs::read(elf_path)?;
     let elf = &Elf::parse(&elf_bytes)?;
 
+    if let Some(ref cdp) = opts.chip_description_path {
+        probe_rs::config::add_target_from_yaml(Path::new(cdp))?;
+    }
     let target_info = TargetInfo::new(chip_name, elf)?;
 
     let probe = probe::open(opts)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     let elf_bytes = fs::read(elf_path)?;
     let elf = &Elf::parse(&elf_bytes)?;
 
-    if let Some(ref cdp) = opts.chip_description_path {
+    if let Some(cdp) = &opts.chip_description_path {
         probe_rs::config::add_target_from_yaml(Path::new(cdp))?;
     }
     let target_info = TargetInfo::new(chip_name, elf)?;


### PR DESCRIPTION
Fixes: https://github.com/knurling-rs/probe-run/issues/291

I need the way to pass my own chip description file to probe-run because my target chip is a original soft processor core implemented on a FPGA.

There are other ideas on #291 but I wrote the simplest implementation for now.