### PR TITLE
Add option to disable double buffering while loading firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#319] Warn on target chip mismatch
 - [#317] Clarify "can't determine stack overflow" error message
 - [#314] Clarify documentation in README
+- [#305] Add option to disable double buffering while loading firmware
 - [#293] Update snapshot tests to new TRACE output
 
 [#339]: https://github.com/knurling-rs/probe-run/pull/339
@@ -39,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [#319]: https://github.com/knurling-rs/probe-run/pull/319
 [#317]: https://github.com/knurling-rs/probe-run/pull/317
 [#314]: https://github.com/knurling-rs/probe-run/pull/314
+[#305]: https://github.com/knurling-rs/probe-run/pull/305
 [#293]: https://github.com/knurling-rs/probe-run/pull/293
 
 ## [v0.3.3] - 2022-03-14

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,10 @@ pub(crate) struct Opts {
     #[structopt(long)]
     pub(crate) json: bool,
 
+    /// Disable use of double buffering while downloading flash
+    #[structopt(long = "disable-double-buffering")]
+    pub(crate) disable_double_buffering: bool,
+
     /// Arguments passed after the ELF file path are discarded
     #[structopt(name = "REST")]
     _rest: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
         let mut options = flashing::DownloadOptions::default();
         options.dry_run = false;
         options.progress = Some(&fp);
+        options.disable_double_buffering = opts.disable_double_buffering;
 
         flashing::download_file_with_options(&mut sess, elf_path, Format::Elf, options)?;
         log::info!("success!");


### PR DESCRIPTION
probe-rs/probe-rs#1030 exposes an option to disable double-buffering when downloading firmware, which seems required currently for the STM32L071x family of chips (probe-rs/probe-rs#883).  This PR allows use of that option for `probe-run`

This won't compile now as Cargo.toml is using the released 0.12 verson of probe-rs.  I've tested it locally by adding the following patch:

```toml
# Cargo.toml
[patch."crates-io"]
probe-rs = {git = "https://github.com/probe-rs/probe-rs", version = "0.12"}
probe-rs-rtt = {git = "https://github.com/probe-rs/probe-rs", version = "0.12"}
```