### PR TITLE
bump crate version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [v0.3.2] - 2022-03-10
+
 - [#303] Don't bail, but only warn if using `--no-flash` with `defmt`
 - [#302] Make stack painting fast again! 🇪🇺
 - [#301] Add way to pass chip description file
@@ -26,10 +28,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 # [v0.3.1] - 2021-11-26
 
-- [#287]: unwind: skip FDEs with initial address of 0 
+- [#287]: unwind: skip FDEs with initial address of 0
 - [#286]: Update dependencies
 - [#285]: Update `probe-rs` and `probe-rs-rtt` to `0.12`
-- [#282]: Include program counter value in backtrace when -v is passed 
+- [#282]: Include program counter value in backtrace when -v is passed
 - [#281]: Report flashing size using probe-rs's FlashProgress system
 - [#280]: Turn symbol demangling back on
 
@@ -369,7 +371,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/probe-run/compare/v0.3.1...main
+[Unreleased]: https://github.com/knurling-rs/probe-run/compare/v0.3.2...main
+[v0.3.2]: https://github.com/knurling-rs/probe-run/compare/v0.3.1...v0.3.2
 [v0.3.1]: https://github.com/knurling-rs/probe-run/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/knurling-rs/probe-run/compare/v0.2.5...v0.3.0
 [v0.2.4]: https://github.com/knurling-rs/probe-run/compare/v0.2.4...v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,8 +200,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-decoder"
-version = "0.3.1"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#b396257be01f477eda2ac16f7e62dece31749963"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f619a4bf5d95e044c1746bafd0552cd1de7b041dc361d506cfa6d9831f47c8b6"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -221,7 +222,8 @@ dependencies = [
 [[package]]
 name = "defmt-json-schema"
 version = "0.1.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#b396257be01f477eda2ac16f7e62dece31749963"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b04d228e57a61cf385d86bc8980bb41b47c6fc0eace90592668df97b2dad6a"
 dependencies = [
  "log",
  "serde",
@@ -229,8 +231,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-parser"
-version = "0.3.0"
-source = "git+https://github.com/knurling-rs/defmt?branch=main#b396257be01f477eda2ac16f7e62dece31749963"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
 
 [[package]]
 name = "diff"
@@ -697,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "probe-run"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "addr2line",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "probe-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/probe-run"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 addr2line = { version = "0.17", default-features = false, features = [
@@ -19,8 +19,7 @@ addr2line = { version = "0.17", default-features = false, features = [
 ] }
 anyhow = "1"
 colored = "2"
-defmt-decoder = { version = "=0.3.1", git = "https://github.com/knurling-rs/defmt", branch = "main", features = ["unstable"] }
-#   remove git version before release ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+defmt-decoder = { version = "=0.3.2", branch = "main", features = ["unstable"] }
 gimli = { version = "0.26", default-features = false }
 git-version = "0.3"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ addr2line = { version = "0.17", default-features = false, features = [
 ] }
 anyhow = "1"
 colored = "2"
-defmt-decoder = { version = "=0.3.2", branch = "main", features = ["unstable"] }
+defmt-decoder = { version = "=0.3.2", features = ["unstable"] }
 gimli = { version = "0.26", default-features = false }
 git-version = "0.3"
 log = "0.4"


### PR DESCRIPTION
in preparation for crates.io release
blocked on defmt-decoder crates.io release