### PR TITLE
Disable output colorization on terminals that don't support it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ probe-rs = "0.12"
 probe-rs-rtt = "0.12"
 signal-hook = "0.3"
 structopt = "0.3"
+terminfo = "0.7"
 
 [dev-dependencies]
 dirs = "4"


### PR DESCRIPTION
The current version of the colored crate ignores the capabilities of
the terminal (see https://github.com/mackwic/colored/issues/108),
which makes the outupt of probe-run unparseable in e.g. emacs
compilation mode. As a temporary workaround, this patch overrides
colorization if probe-run is called from a terminal without color
support.