### PR TITLE
Warn on target chip mismatch

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -11,10 +11,11 @@ use crate::cortexm;
 pub(crate) struct Elf<'file> {
     elf: ObjectFile<'file>,
     symbols: Symbols,
-    pub(crate) live_functions: HashSet<&'file str>,
-    pub(crate) defmt_table: Option<Table>,
-    pub(crate) defmt_locations: Option<Locations>,
+
     pub(crate) debug_frame: DebugFrame<'file>,
+    pub(crate) defmt_locations: Option<Locations>,
+    pub(crate) defmt_table: Option<Table>,
+    pub(crate) live_functions: HashSet<&'file str>,
     pub(crate) vector_table: cortexm::VectorTable,
 }
 
@@ -35,10 +36,10 @@ impl<'file> Elf<'file> {
         Ok(Self {
             elf,
             symbols,
-            live_functions,
-            defmt_table,
-            defmt_locations,
             debug_frame,
+            defmt_locations,
+            defmt_table,
+            live_functions,
             vector_table,
         })
     }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, convert::TryInto, env, ops::Deref};
+use std::{collections::HashSet, convert::TryInto, env, ops::Deref, path::Path};
 
 use anyhow::{anyhow, bail};
 use defmt_decoder::{Locations, Table};
@@ -15,12 +15,16 @@ pub(crate) struct Elf<'file> {
     pub(crate) debug_frame: DebugFrame<'file>,
     pub(crate) defmt_locations: Option<Locations>,
     pub(crate) defmt_table: Option<Table>,
+    pub(crate) elf_path: &'file Path,
     pub(crate) live_functions: HashSet<&'file str>,
     pub(crate) vector_table: cortexm::VectorTable,
 }
 
 impl<'file> Elf<'file> {
-    pub(crate) fn parse(elf_bytes: &'file [u8]) -> Result<Self, anyhow::Error> {
+    pub(crate) fn parse(
+        elf_bytes: &'file [u8],
+        elf_path: &'file Path,
+    ) -> Result<Self, anyhow::Error> {
         let elf = ObjectFile::parse(elf_bytes)?;
 
         let live_functions = extract_live_functions(&elf)?;
@@ -39,6 +43,7 @@ impl<'file> Elf<'file> {
             debug_frame,
             defmt_locations,
             defmt_table,
+            elf_path,
             live_functions,
             vector_table,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     }
 
     let elf_bytes = fs::read(elf_path)?;
-    let elf = &Elf::parse(&elf_bytes)?;
+    let elf = &Elf::parse(&elf_bytes, elf_path)?;
 
     if let Some(cdp) = &opts.chip_description_path {
         probe_rs::config::add_target_from_yaml(Path::new(cdp))?;

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -56,12 +56,12 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
     });
     let target = match target {
         Some(target) => target,
-        None => return,
+        None => return, // NOTE(return) If probe-run is not called through `cargo run` the elf_path
+                        // might not contain the compilation target. In that case we return early.
     };
 
     // NOTE(indexing): There *must* always be at least one core.
     let core_type = cores[0].core_type;
-
     let matches = match core_type {
         CoreType::Armv6m => target == "thumbv6m-none-eabi",
         CoreType::Armv7m => target == "thumbv7m-none-eabi",
@@ -71,7 +71,9 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
                 || target == "thumbv8m.main-none-eabi"
                 || target == "thumbv8m.main-none-eabihf"
         }
-        CoreType::Riscv => return,
+        CoreType::Riscv => return, // NOTE(return) Since we do not get any info about instruction
+                                   // set support from probe-rs we do not know which compilation
+                                   // targets fit.
     };
 
     if matches {

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -66,7 +66,11 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
         CoreType::Armv6m => target == "thumbv6m-none-eabi",
         CoreType::Armv7m => target == "thumbv7m-none-eabi",
         CoreType::Armv7em => target == "thumbv7em-none-eabi" || target == "thumbv7em-none-eabihf",
-        CoreType::Armv8m => todo!(),
+        CoreType::Armv8m => {
+            target == "thumbv8m.base-none-eabi"
+                || target == "thumbv8m.main-none-eabi"
+                || target == "thumbv8m.main-none-eabihf"
+        }
         CoreType::Riscv => return,
     };
 
@@ -79,7 +83,9 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
         CoreType::Armv7em => {
             "should be 'thumbv7em-none-eabi' (no FPU) or 'thumbv7em-none-eabihf' (with FPU)"
         }
-        CoreType::Armv8m => todo!(),
+        CoreType::Armv8m => {
+            "should be 'thumbv8m.base-none-eabi' (M23), 'thumbv8m.main-none-eabi' (M33 no FPU), or 'thumbv8m.main-none-eabihf' (M33 with FPU)"
+        }
         CoreType::Riscv => unreachable!(),
     };
     log::warn!("Compilation target ({target}) and core type ({core_type:?}) do not match. Your compilation target {recommendation}.");


### PR DESCRIPTION
This PR makes `probe-run` emit a warning, in case the chip type (obtained from `probe-rs`) and the compilation target (obtained from the path to the elf file) do not match. The path will contain the compilation target if `probe-run` is called through `cargo run`. In other cases the path might not contain the compilation target. In these cases we take no action and just move on.

**Example**
```console
$ cargo rb hello -q
(HOST) WARN  Compilation target (thumbv8m.base-none-eabi) and core type (Armv7em) do not match. Your compilation target should be 'thumbv7em-none-eabi' (no FPU) or 'thumbv7em-none-eabihf' (with FPU).
...
```

Fixes #115.

**Todo**
- [x] Handle `CoreType::Armv8m`