### PR TITLE
Disable terminal colorization if `TERM=dumb` is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ use crate::{backtrace::Outcome, canary::Canary, elf::Elf, target_info::TargetInf
 const TIMEOUT: Duration = Duration::from_secs(1);
 
 fn main() -> anyhow::Result<()> {
+    configure_terminal_colorization();
+
     #[allow(clippy::redundant_closure)]
     cli::handle_arguments().map(|code| process::exit(code))
 }
@@ -431,4 +433,14 @@ fn setup_logging_channel(
 /// Print a line to separate different execution stages.
 fn print_separator() -> io::Result<()> {
     writeln!(io::stderr(), "{}", "─".repeat(80).dimmed())
+}
+
+fn configure_terminal_colorization() {
+    // ! This should be detected by `colored`, but currently is not.
+    // See https://github.com/mackwic/colored/issues/108 and https://github.com/knurling-rs/probe-run/pull/318.
+
+    match env::var("TERM").as_deref() {
+        Ok("dumb") => colored::control::set_override(false),
+        _ => {}
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,8 +439,7 @@ fn configure_terminal_colorization() {
     // ! This should be detected by `colored`, but currently is not.
     // See https://github.com/mackwic/colored/issues/108 and https://github.com/knurling-rs/probe-run/pull/318.
 
-    match env::var("TERM").as_deref() {
-        Ok("dumb") => colored::control::set_override(false),
-        _ => {}
+    if let Ok("dumb") = env::var("TERM").as_deref() {
+        colored::control::set_override(false)
     }
 }


### PR DESCRIPTION
This PR fixes the problem @fhars described in #318:
> The current version of the colored crate ignores the capabilities of the terminal (see https://github.com/mackwic/colored/issues/108), which makes the outupt of probe-run unparseable in e.g. emacs compilation mode.

It also supersedes #318 as a fix to the problem. The reason for not going with #318 is that it adds the `terminfo` crate as a dependency which seems unmaintained and with many outdated dependencies.