### PR TITLE
Make use of i/o locking being static since rust `1.61`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#326] Make use of i/o locking being static since rust `1.61`.
 - [#321] CI: Add changelog-enforcer
 - [#320] Disable terminal colorization if `TERM=dumb` is set
 - [#319] Warn on target chip mismatch
@@ -13,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
 
+[#326]: https://github.com/knurling-rs/probe-run/pull/326
 [#321]: https://github.com/knurling-rs/probe-run/pull/321
 [#320]: https://github.com/knurling-rs/probe-run/pull/320
 [#319]: https://github.com/knurling-rs/probe-run/pull/319

--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -14,8 +14,7 @@ use super::{symbolicate::Frame, Settings};
 
 /// Pretty prints processed backtrace frames up to `backtrace_limit`
 pub(crate) fn backtrace(frames: &[Frame], settings: &Settings) -> io::Result<()> {
-    let stderr = io::stderr();
-    let mut stderr = stderr.lock();
+    let mut stderr = io::stderr().lock();
     writeln!(stderr, "{}", "stack backtrace:".dimmed())?;
 
     let mut frame_index = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,8 +275,7 @@ fn extract_and_print_logs(
 
     print_separator()?;
 
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
+    let mut stdout = io::stdout().lock();
     let mut read_buf = [0; 1024];
     let mut was_halted = false;
     while !exit.load(Ordering::Relaxed) {


### PR DESCRIPTION
See https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html#static-handles-for-locked-stdio.