### PR TITLE
Optimize stack usage measuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#330] Fix `fn round_up`
 - [#329] Update probe-rs to 0.13.0 (does not yet implement 64-bit support)
 - [#328] Simplify, by capturing identifiers in logging macros
+- [#327] Optimize stack usage measuring
 - [#326] Make use of i/o locking being static since rust `1.61`.
 - [#321] CI: Add changelog-enforcer
 - [#320] Disable terminal colorization if `TERM=dumb` is set
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [#330]: https://github.com/knurling-rs/probe-run/pull/330
 [#329]: https://github.com/knurling-rs/probe-run/pull/329
 [#328]: https://github.com/knurling-rs/probe-run/pull/328
+[#327]: https://github.com/knurling-rs/probe-run/pull/327
 [#326]: https://github.com/knurling-rs/probe-run/pull/326
 [#321]: https://github.com/knurling-rs/probe-run/pull/321
 [#320]: https://github.com/knurling-rs/probe-run/pull/320

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -340,7 +340,7 @@ mod measure_subroutine {
     fn search_with_probe(core: &mut Core, low_addr: u32) -> Result<Option<u32>, probe_rs::Error> {
         let mut buf = [0; self::SUBROUTINE.len()];
         core.read_8(low_addr as u64, &mut buf)?;
-        match buf.iter().position(|b| *b != CANARY_U8) {
+        match buf.into_iter().position(|b| b != CANARY_U8) {
             Some(pos) => Ok(Some(low_addr + pos as u32)),
             None => Ok(None),
         }

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -398,7 +398,7 @@ mod measure_subroutine {
     ];
 }
 
-/// Execute subroutine.
+/// Prepare and run subroutine. Also clean up afterwards.
 ///
 /// # How?
 ///

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -218,7 +218,7 @@ macro_rules! assert_subroutine {
 ///    200ec:    4288    cmp      r0, r1
 ///    200ee:    d801    bhi.n    #6 <paint+0x8>
 ///    200f0:    c004    stmia    r0!, {r2}
-///    200f2:    e7fb    b.n      #0xfffffffa <paint>
+///    200f2:    e7fb    b.n      #-6 <paint>
 ///
 /// 000200f4 <paint+0x8>:
 ///    200f4:    be00    bkpt     0x0000
@@ -253,7 +253,7 @@ mod paint_subroutine {
         0x88, 0x42, // cmp      r0, r1
         0x01, 0xd8, // bhi.n    #6 <paint+0x8>
         0x04, 0xc0, // stmia    r0!, {r2}
-        0xfb, 0xe7, // b.n      #0xfffffffa <paint>
+        0xfb, 0xe7, // b.n      #-6 <paint>
         0x00, 0xbe, // bkpt     0x0000
         0x00, 0xbe, // bkpt     0x0000 (padding instruction)
     ];
@@ -293,7 +293,7 @@ mod paint_subroutine {
 ///     200f2:    4293    cmp      r3, r2
 ///     200f4:    d102    bne.n    #8 <measure+0x10>
 ///     200f6:    1d00    adds     r0, r0, #4
-///     200f8:    e7f8    b.n      #0xfffffff8 <measure>
+///     200f8:    e7f8    b.n      #-8 <measure>
 ///
 /// 000200fa <measure+0xe>:
 ///     200fa:    2000    movs     r0, #0
@@ -371,7 +371,7 @@ mod measure_subroutine {
         0x93, 0x42, // cmp      r3, r2
         0x02, 0xd1, // bne.n    #8 <measure+0x10>
         0x00, 0x1d, // adds     r0, r0, #4
-        0xf8, 0xe7, // b.n      #0xfffffff8 <measure>
+        0xf8, 0xe7, // b.n      #-8 <measure>
         0x00, 0x20, // movs     r0, #0
         0x00, 0xbe, // bkpt     0x0000
         0x00, 0xbe, // bkpt     0x0000 (padding instruction)

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -400,7 +400,7 @@ fn execute_subroutine<const N: usize>(
     core.write_8(low_addr as u64, &subroutine)?;
 
     // store current PC and set PC to beginning of subroutine
-    let previous_pc: u32 = core.read_core_reg(PC)?;
+    let previous_pc = core.read_core_reg(PC)?;
     core.write_core_reg(PC, low_addr)?;
 
     // execute the subroutine and wait for it to finish
@@ -408,7 +408,7 @@ fn execute_subroutine<const N: usize>(
     core.wait_for_core_halted(TIMEOUT)?;
 
     // reset PC to where it was before
-    core.write_core_reg(PC, previous_pc)?;
+    core.write_core_reg::<u32>(PC, previous_pc)?;
 
     Ok(())
 }

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -319,8 +319,7 @@ mod measure_subroutine {
     ///
     /// The returned `Option<u32>` is None, if the memory is untouched. Otherwise it
     /// gives the position of the first (lowest) 4-byte-word which isn't the same as
-    /// the pattern anymore. Because we are searching for 4-byte-words, the returned
-    /// `u32` will always be a multiple of 4.
+    /// the pattern anymore.
     ///
     /// ## Assumptions
     /// - Expects the [`Core`] to be halted and will leave it halted when the function
@@ -339,7 +338,7 @@ mod measure_subroutine {
         match buf.iter().position(|b| *b != CANARY_U8) {
             // if we find a touched value, we return early
             Some(pos) => return Ok(Some(pos as u32)),
-            // otherwise continue
+            // otherwise we continue
             None => {}
         }
 

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -214,7 +214,8 @@ macro_rules! assert_subroutine {
 ///
 /// # Assembly
 ///
-/// The assembly is generated from aboves rust code, using the jorge-hack:
+/// The assembly is generated from the Rust function `fn measure()` above, using the
+/// jorge-hack.
 ///
 /// ```armasm
 /// 000200ec <paint>:
@@ -292,7 +293,8 @@ mod paint_subroutine {
 ///
 /// # Assembly
 ///
-/// The assembly is generated from aboves rust code, using the jorge-hack.
+/// The assembly is generated from the Rust function `fn measure()` above, using the
+/// jorge-hack.
 ///
 /// ```armasm
 /// 000200ec <measure>:

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -214,7 +214,7 @@ macro_rules! assert_subroutine {
 ///
 /// # Assembly
 ///
-/// The assembly is generated from the Rust function `fn measure()` above, using the
+/// The assembly is generated from the Rust function `fn paint()` above, using the
 /// jorge-hack.
 ///
 /// ```armasm

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -214,9 +214,9 @@ macro_rules! assert_subroutine {
 /// ```armasm
 /// 000200ec <paint>:
 ///    200ec:    4288    cmp      r0, r1
-///    200ee:    d801    bhi.n    200f4 <paint+0x8>
+///    200ee:    d801    bhi.n    #6 <paint+0x8>
 ///    200f0:    c004    stmia    r0!, {r2}
-///    200f2:    e7fb    b.n      200ec <paint>
+///    200f2:    e7fb    b.n      #0xfffffffa <paint>
 ///
 /// 000200f4 <paint+0x8>:
 ///    200f4:    be00    bkpt     0x0000
@@ -255,9 +255,9 @@ mod paint_subroutine {
 
     const SUBROUTINE: [u8; 12] = [
         0x88, 0x42, // cmp      r0, r1
-        0x01, 0xd8, // bhi.n    200f4 <paint+0x8>
+        0x01, 0xd8, // bhi.n    #6 <paint+0x8>
         0x04, 0xc0, // stmia    r0!, {r2}
-        0xfb, 0xe7, // b.n      200ec <paint>
+        0xfb, 0xe7, // b.n      #0xfffffffa <paint>
         0x00, 0xbe, // bkpt     0x0000
         0x00, 0xbe, // bkpt     0x0000 (padding instruction)
     ];
@@ -292,12 +292,12 @@ mod paint_subroutine {
 /// ```armasm
 /// 000200ec <measure>:
 ///     200ec:    4288    cmp      r0, r1
-///     200ee:    d204    bcs.n    200fa <measure+0xe>
+///     200ee:    d204    bcs.n    #0xc <measure+0xe>
 ///     200f0:    6803    ldr      r3, [r0, #0]
 ///     200f2:    4293    cmp      r3, r2
-///     200f4:    d102    bne.n    200fc <measure+0x10>
+///     200f4:    d102    bne.n    #8 <measure+0x10>
 ///     200f6:    1d00    adds     r0, r0, #4
-///     200f8:    e7f8    b.n      200ec <measure>
+///     200f8:    e7f8    b.n      #0xfffffff8 <measure>
 ///
 /// 000200fa <measure+0xe>:
 ///     200fa:    2000    movs     r0, #0
@@ -358,12 +358,12 @@ mod measure_subroutine {
 
     const SUBROUTINE: [u8; 20] = [
         0x88, 0x42, // cmp      r0, r1
-        0x04, 0xd2, // bcs.n    200fa <measure+0xe>
+        0x04, 0xd2, // bcs.n    #0xc <measure+0xe>
         0x03, 0x68, // ldr      r3, [r0, #0]
         0x93, 0x42, // cmp      r3, r2
-        0x02, 0xd1, // bne.n    200fc <measure+0x10>
+        0x02, 0xd1, // bne.n    #8 <measure+0x10>
         0x00, 0x1d, // adds     r0, r0, #4
-        0xf8, 0xe7, // b.n      200ec <measure>
+        0xf8, 0xe7, // b.n      #0xfffffff8 <measure>
         0x00, 0x20, // movs     r0, #0
         0x00, 0xbe, // bkpt     0x0000
         0x00, 0xbe, // bkpt     0x0000 (padding instruction)

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -340,11 +340,14 @@ mod measure_subroutine {
         }
 
         // prepare subroutine
-        super::prepare_subroutine(core, low_addr, stack_size, self::SUBROUTINE)?;
+        let previous_pc = super::prepare_subroutine(core, low_addr, stack_size, self::SUBROUTINE)?;
 
         // execute the subroutine and wait for it to finish
         core.run()?;
         core.wait_for_core_halted(TIMEOUT)?;
+
+        // reset PC to where it was before
+        core.write_core_reg(PC, previous_pc)?;
 
         // read out and return the result
         self::get_result(core)

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -115,21 +115,19 @@ impl Canary {
         if self.measure_stack {
             log::info!("reading {size_kb:.2} KiB of RAM for stack usage estimation");
         }
-        let mut canary = vec![0; self.size];
         let start = Instant::now();
-        core.read_8(self.address.into(), &mut canary)?;
+        let touched_address =
+            measure_subroutine::execute(core, self.address as u64, self.size as u64)?;
         let seconds = start.elapsed().as_secs_f64();
         log::trace!(
             "reading canary took {seconds:.3}s ({:.2} KiB/s)",
             size_kb / seconds
         );
 
-        let min_stack_usage = match canary.iter().position(|b| *b != CANARY_U8) {
-            Some(pos) => {
-                let touched_address = self.address + pos as u32;
+        let min_stack_usage = match touched_address {
+            Some(touched_address) => {
                 log::debug!("canary was touched at {touched_address:#010X}");
-
-                Some(elf.vector_table.initial_stack_pointer - touched_address)
+                Some(elf.vector_table.initial_stack_pointer - touched_address as u32)
             }
             None => None,
         };
@@ -263,6 +261,120 @@ mod paint_subroutine {
         0xfb, 0xe7, // b.n      200ec <paint>
         0x00, 0xbe, // bkpt     0x0000
         0x00, 0xbe, // bkpt     0x0000 (padding instruction)
+    ];
+}
+
+/// Search for lowest touched address in memory.
+///
+/// ### Corresponds to following rust code
+///
+/// ```rust
+/// #[export_name = "measure"]
+/// unsafe fn measure(mut low_addr: u32, high_addr: u32, pattern: u32) -> u32 {
+///     let mut result = 0;
+///
+///     loop {
+///         if low_addr >= high_addr {
+///             break;
+///         } else if (low_addr as *const u32).read() != pattern {
+///             result = low_addr;
+///             break;
+///         } else {
+///             low_addr += 4;
+///             continue;
+///         }
+///     }
+///
+///     result
+/// }
+/// ```
+///
+/// ### Generated assembly
+///
+/// The assembly is generated from abothes rust code, using the jorge-hack. The labels
+/// `<end>` and `<no_result>` got manually inserted for readability.
+///
+/// ```armasm
+/// 000200ec <measure>:
+///     200ec:    4288    cmp      r0, r1
+///     200ee:    d204    bcs.n    200fa <no_result>
+///     200f0:    6803    ldr      r3, [r0, #0]
+///     200f2:    4293    cmp      r3, r2
+///     200f4:    d102    bne.n    200fc <end>
+///     200f6:    1d00    adds     r0, r0, #4
+///     200f8:    e7f8    b.n      200ec <measure>
+/// 000200fa <no_result>:
+///     200fa:    2000    movs     r0, #0
+/// 000200fc <end>:
+///     200fc:    be00    bkpt     0x0000
+/// //                    ^^^^ this was `bx lr`
+/// ```
+///
+/// ### Register-parameter-mapping
+///
+/// - r0: low_addr, and return value
+/// - r1: high_addr
+/// - r2: pattern
+mod measure_subroutine {
+    use super::*;
+
+    /// Execute the subroutine.
+    ///
+    /// The returned `Option<u32>` is None, if the memory is untouched. Otherwise it
+    /// gives the position of the first (lowest) 4-byte-word which isn't the same as
+    /// the pattern anymore. Because we are searching for 4-byte-words, the returned
+    /// `u32` will always be a multiple of 4.
+    ///
+    /// ## Assumptions
+    /// - Expects the [`Core`] to be halted and will leave it halted when the function
+    /// returns.
+    /// - `low_addr` and `size` need to be 4-byte-aligned.
+    pub fn execute(
+        core: &mut Core,
+        low_addr: u64,
+        stack_size: u64,
+    ) -> Result<Option<u64>, probe_rs::Error> {
+        assert_subroutine!(low_addr, stack_size, self::SUBROUTINE.len() as u64);
+
+        // use probe to search through the memory the subroutine will be written to
+        // NOTE: SUBROUTINE.len() is always a multiple of 4, therefore we can divide by 4 here
+        let mut buf = [0; self::SUBROUTINE.len()];
+        core.read_8(low_addr, &mut buf)?;
+        match buf.iter().position(|b| *b != CANARY_U8) {
+            // if we find a touched value, we return early
+            Some(pos) => return Ok(Some(pos as u64)),
+            // otherwise continue
+            None => {}
+        }
+
+        // prepare subroutine
+        let _ = super::prepare_subroutine(core, low_addr, stack_size, self::SUBROUTINE)?;
+
+        // execute the subroutine and wait for it to finish
+        core.run()?;
+        core.wait_for_core_halted(TIMEOUT)?;
+
+        // read out and return the result
+        match core.read_core_reg(RegisterId(0))? {
+            0 => Ok(None),
+            n => Ok(Some(n - low_addr)),
+        }
+    }
+
+    const SUBROUTINE: [u8; 20] = [
+        // <measure>
+        0x88, 0x42, // cmp     r0, r1
+        0x04, 0xd2, // bcs.n   200fa <no_result>
+        0x03, 0x68, // ldr     r3, [r0, #0]
+        0x93, 0x42, // cmp     r3, r2
+        0x02, 0xd1, // bne.n   200fc <end>
+        0x00, 0x1d, // adds    r0, r0, #4
+        0xf8, 0xe7, // b.n     200ec <measure>
+        // <no_result>
+        0x00, 0x20, // movs    r0, #0
+        // <end>
+        0x00, 0xbe, // bkpt    0x0000
+        0x00, 0xbe, // bkpt    0x0000 (padding instruction)
     ];
 }
 

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -353,7 +353,7 @@ mod measure_subroutine {
         // read out and return the result
         match core.read_core_reg(RegisterId(0))? {
             0 => Ok(None),
-            n => Ok(Some(n - low_addr)),
+            n => Ok(Some(n)),
         }
     }
 

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -341,7 +341,7 @@ mod measure_subroutine {
         let mut buf = [0; self::SUBROUTINE.len()];
         core.read_8(low_addr as u64, &mut buf)?;
         match buf.iter().position(|b| *b != CANARY_U8) {
-            Some(pos) => Ok(Some(pos as u32)),
+            Some(pos) => Ok(Some(low_addr + pos as u32)),
             None => Ok(None),
         }
     }


### PR DESCRIPTION
This PR optimizes the stack usage measuring by not using the probe but a subroutine to search through the memory.

Fixes #258.

## Measurements

The speedup is similarly impressive as in #302:

| canary size | main (bcaf997cedc672ab98dc8feede19a1ca4326be05) | this PR (3ad3f86b37b56192fa6b45613ee9b9ec7b837082) |
| :---: | :---: | :---: |
| 1024 B     | 0.007s | 0.014s |
| 261060 B | 1.912s | 0.028s |

It makes sense that the time actually gets worse for a small canary size of 1024 bytes, since we are doing a lot of setup work (flash subroutine, set registers, set and reset program counter etc.). But we see that this totally pays off, since for a rather big canary of 256KiB we are almost 70 times faster!

## Further work
This PR enables us to drastically simplify the canary logic, because since both painting and measuring are pretty fast now, we can always paint the full stack.