### PR TITLE
Update probe-rs to version 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#329] Update probe-rs to 0.13.0 (does not yet implement 64-bit support)
 - [#328] Simplify, by capturing identifiers in logging macros
 - [#326] Make use of i/o locking being static since rust `1.61`.
 - [#321] CI: Add changelog-enforcer
@@ -14,8 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#317] Clarify "can't determine stack overflow" error message
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
-- Update probe-rs to 0.13.0 (does not yet implement 64-bit support)
 
+[#329]: https://github.com/knurling-rs/probe-run/pull/329
 [#328]: https://github.com/knurling-rs/probe-run/pull/328
 [#326]: https://github.com/knurling-rs/probe-run/pull/326
 [#321]: https://github.com/knurling-rs/probe-run/pull/321

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#317] Clarify "can't determine stack overflow" error message
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
+- Update probe-rs to 0.13.0 (does not yet implement 64-bit support)
 
 [#328]: https://github.com/knurling-rs/probe-run/pull/328
 [#326]: https://github.com/knurling-rs/probe-run/pull/326

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "cpp_demangle",
  "fallible-iterator",
  "gimli",
- "object",
+ "object 0.27.1",
  "rustc-demangle",
 ]
 
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -91,9 +91,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
 dependencies = [
  "funty",
  "radium",
@@ -213,7 +213,7 @@ dependencies = [
  "difference",
  "gimli",
  "log",
- "object",
+ "object 0.27.1",
  "ryu",
  "serde",
  "serde_json",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -440,9 +440,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jaylink"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f58b72b6aa9d25083b8c19d292fe015a936185fa200d15e225e1524a18222e9"
+checksum = "2d891935e08397d85684c1d3c88b6a0a6941c6e15e9f04a1ae9e30079f0b0df0"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -473,9 +473,9 @@ checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libusb1-sys"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
+checksum = "6dfab089105aa85a3b492b421bd90d55e6257f00f8447cc3873c44f8206809ce"
 dependencies = [
  "cc",
  "libc",
@@ -576,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "probe-rs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232e7f2912aba17bef48f84f9d90bfc9e6c1d8c90959fcf1451ccb3a68819ee7"
+checksum = "03a92904dbd29f6af1f7bd6d22dac82569aa4b03bcbfc54441b7c76f7114ea79"
 dependencies = [
  "anyhow",
  "base64",
@@ -662,36 +671,36 @@ dependencies = [
  "jep106",
  "log",
  "num-traits",
- "object",
+ "object 0.29.0",
  "once_cell",
  "probe-rs-target",
  "rusb",
- "scroll",
+ "scroll 0.11.0",
  "serde",
  "serde_yaml",
  "static_assertions",
  "svg",
  "thiserror",
- "thousands",
 ]
 
 [[package]]
 name = "probe-rs-rtt"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a9f49ddd5fa2f079961debbea5f93e4fc168bf89223a0407aa9de60eed8d51"
+checksum = "68a97f5a269ac492bc911663aab10817225792fa69c18a85e567c090e0308ed4"
 dependencies = [
  "log",
  "probe-rs",
- "scroll",
+ "scroll 0.10.2",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "probe-rs-target"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9610234697e695947df2f7b0cd71d4e4e2fe2fea13df90bdc44bb65e0ef16f"
+checksum = "4a024d514369dbabfdb7f476a8a16376b3aabf139454fdba5df012686a68430b"
 dependencies = [
  "base64",
  "jep106",
@@ -712,7 +721,7 @@ dependencies = [
  "insta",
  "log",
  "nix",
- "object",
+ "object 0.27.1",
  "os_pipe",
  "pretty_assertions",
  "probe-rs",
@@ -773,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "redox_syscall"
@@ -811,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "rusb"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a5084628cc5be77b1c750b3e5ee0cc519d2f2491b3f06b78b3aac3328b00ad"
+checksum = "703aa035c21c589b34fb5136b12e68fc8dcf7ea46486861381361dd8ebf5cee0"
 dependencies = [
  "libc",
  "libusb1-sys",
@@ -851,6 +860,12 @@ name = "scroll"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 
 [[package]]
 name = "semver"
@@ -1059,12 +1074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,9 +1145,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ gimli = { version = "0.26", default-features = false }
 git-version = "0.3"
 log = "0.4"
 object = { version = "0.27", default-features = false }
-probe-rs = "0.12"
-probe-rs-rtt = "0.12"
+probe-rs = "0.13"
+probe-rs-rtt = "0.13"
 signal-hook = "0.3"
 structopt = "0.3"
 

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -60,7 +60,7 @@ pub(crate) fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamR
             pc,
             &elf.vector_table,
             &mut output,
-            sp.into(),
+            sp,
             active_ram_region,
         ) {
             output.outcome = outcome;

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -56,13 +56,9 @@ pub(crate) fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamR
     let mut registers = Registers::new(lr, sp, core);
 
     loop {
-        if let Some(outcome) = check_hard_fault(
-            pc,
-            &elf.vector_table,
-            &mut output,
-            sp,
-            active_ram_region,
-        ) {
+        if let Some(outcome) =
+            check_hard_fault(pc, &elf.vector_table, &mut output, sp, active_ram_region)
+        {
             output.outcome = outcome;
         }
 

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -56,9 +56,13 @@ pub(crate) fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamR
     let mut registers = Registers::new(lr, sp, core);
 
     loop {
-        if let Some(outcome) =
-            check_hard_fault(pc, &elf.vector_table, &mut output, sp, active_ram_region)
-        {
+        if let Some(outcome) = check_hard_fault(
+            pc,
+            &elf.vector_table,
+            &mut output,
+            sp.into(),
+            active_ram_region,
+        ) {
             output.outcome = outcome;
         }
 
@@ -114,7 +118,10 @@ pub(crate) fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamR
             let sp = unwrap_or_return_output!(registers.get(registers::SP));
             let ram_bounds = active_ram_region
                 .as_ref()
-                .map(|ram_region| ram_region.range.clone())
+                .map(|ram_region| {
+                    ram_region.range.start.try_into().unwrap_or(u32::MAX)
+                        ..ram_region.range.end.try_into().unwrap_or(u32::MAX)
+                })
                 .unwrap_or(cortexm::VALID_RAM_ADDRESS);
             let stacked = if let Some(stacked) =
                 unwrap_or_return_output!(Stacked::read(registers.core, sp, fpu, ram_bounds))
@@ -195,7 +202,7 @@ fn overflowed_stack(sp: u32, active_ram_region: &Option<RamRegion>) -> bool {
         // NOTE stack is full descending; meaning the stack pointer can be
         // `ORIGIN(RAM) + LENGTH(RAM)`
         let range = active_ram_region.range.start..=active_ram_region.range.end;
-        !range.contains(&sp)
+        !range.contains(&sp.into())
     } else {
         log::warn!("no RAM region appears to contain the stack; probe-run can't determine if this was a stack overflow");
         false

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -200,8 +200,8 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
         main_fn_address.ok_or_else(|| anyhow!("`main` symbol not found"))?;
 
     Ok(Symbols {
-        rtt_buffer_address,
+        rtt_buffer_address: rtt_buffer_address.map(|v| v.into()),
         program_uses_heap,
-        main_fn_address: main_function_address,
+        main_fn_address: main_function_address.into(),
     })
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -200,8 +200,8 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
         main_fn_address.ok_or_else(|| anyhow!("`main` symbol not found"))?;
 
     Ok(Symbols {
-        rtt_buffer_address: rtt_buffer_address.map(|v| v.into()),
+        rtt_buffer_address,
         program_uses_heap,
-        main_fn_address: main_function_address.into(),
+        main_fn_address: main_function_address,
     })
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -44,7 +44,8 @@ impl<'c, 'probe> Registers<'c, 'probe> {
     ) -> anyhow::Result</* cfa_changed: */ bool> {
         match rule {
             CfaRule::RegisterAndOffset { register, offset } => {
-                let cfa = (i64::from(self.get(gimli2probe(register))?) + offset) as u32; // wrapping_add_signed
+                // Could be simplified when wrapping_add_signed becomes stable
+                let cfa = (i64::from(self.get(gimli2probe(register))?) + offset) as u32;
                 let old_cfa = self.cache.get(&SP.0);
                 let changed = old_cfa != Some(&cfa);
                 if changed {

--- a/src/stacked.rs
+++ b/src/stacked.rs
@@ -64,7 +64,7 @@ impl Stacked {
             return Ok(None);
         }
 
-        core.read_32(start, registers)?;
+        core.read_32(start.into(), registers)?;
 
         Ok(Some(Stacked {
             lr: registers[0],

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -72,14 +72,14 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
                 || target == "thumbv8m.main-none-eabi"
                 || target == "thumbv8m.main-none-eabihf"
         }
+        CoreType::Armv8a => {
+            log::warn!("Unsupported architecture ({core_type:?}");
+            return;
+        }
         // NOTE(return) Since we do not get any info about instruction
         // set support from probe-rs we do not know which compilation
         // targets fit.
         CoreType::Riscv => return,
-        _ => {
-            log::warn!("Unsupported architecture ({core_type:?}");
-            return;
-        }
     };
 
     if matches {
@@ -88,13 +88,15 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
     let recommendation = match core_type {
         CoreType::Armv6m => "must be 'thumbv6m-none-eabi'",
         CoreType::Armv7m => "should be 'thumbv7m-none-eabi'",
+        CoreType::Armv7a => "should be 'thumbv7a-none-eabi'",
         CoreType::Armv7em => {
             "should be 'thumbv7em-none-eabi' (no FPU) or 'thumbv7em-none-eabihf' (with FPU)"
         }
         CoreType::Armv8m => {
             "should be 'thumbv8m.base-none-eabi' (M23), 'thumbv8m.main-none-eabi' (M33 no FPU), or 'thumbv8m.main-none-eabihf' (M33 with FPU)"
         }
-        _ => unreachable!(),
+        CoreType::Armv8a => unreachable!(),
+        CoreType::Riscv => unreachable!(),
     };
     log::warn!("Compilation target ({target}) and core type ({core_type:?}) do not match. Your compilation target {recommendation}.");
 }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -65,15 +65,21 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
     let matches = match core_type {
         CoreType::Armv6m => target == "thumbv6m-none-eabi",
         CoreType::Armv7m => target == "thumbv7m-none-eabi",
+        CoreType::Armv7a => target == "thumbv7a-none-eabi",
         CoreType::Armv7em => target == "thumbv7em-none-eabi" || target == "thumbv7em-none-eabihf",
         CoreType::Armv8m => {
             target == "thumbv8m.base-none-eabi"
                 || target == "thumbv8m.main-none-eabi"
                 || target == "thumbv8m.main-none-eabihf"
         }
-        CoreType::Riscv => return, // NOTE(return) Since we do not get any info about instruction
-                                   // set support from probe-rs we do not know which compilation
-                                   // targets fit.
+        // NOTE(return) Since we do not get any info about instruction
+        // set support from probe-rs we do not know which compilation
+        // targets fit.
+        CoreType::Riscv => return,
+        _ => {
+            log::warn!("Unsupported architecture ({core_type:?}");
+            return;
+        }
     };
 
     if matches {
@@ -88,7 +94,7 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
         CoreType::Armv8m => {
             "should be 'thumbv8m.base-none-eabi' (M23), 'thumbv8m.main-none-eabi' (M33 no FPU), or 'thumbv8m.main-none-eabihf' (M33 with FPU)"
         }
-        CoreType::Riscv => unreachable!(),
+        _ => unreachable!(),
     };
     log::warn!("Compilation target ({target}) and core type ({core_type:?}) do not match. Your compilation target {recommendation}.");
 }
@@ -105,7 +111,7 @@ fn extract_active_ram_region(
                 // NOTE stack is full descending; meaning the stack pointer can be
                 // `ORIGIN(RAM) + LENGTH(RAM)`
                 let inclusive_range = ram_region.range.start..=ram_region.range.end;
-                if inclusive_range.contains(&initial_stack_pointer) {
+                if inclusive_range.contains(&initial_stack_pointer.into()) {
                     log::debug!(
                         "RAM region: 0x{:08X}-0x{:08X}",
                         ram_region.range.start,
@@ -121,7 +127,7 @@ fn extract_active_ram_region(
         .cloned()
 }
 
-fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
+fn extract_stack_info(elf: &Elf, ram_range: &Range<u64>) -> Option<StackInfo> {
     // How does it work?
     // - the upper end of the stack is the initial SP, minus one
     // - the lower end of the stack is the highest address any section in the elf file uses, plus one
@@ -129,7 +135,8 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
     let initial_stack_pointer = elf.vector_table.initial_stack_pointer;
 
     // SP points one word (4-byte) past the end of the stack.
-    let mut stack_range = ram_range.start..=initial_stack_pointer - 4;
+    let mut stack_range =
+        ram_range.start.try_into().unwrap_or(u32::MAX)..=initial_stack_pointer - 4;
 
     for section in elf.sections() {
         let size: u32 = section.size().try_into().expect("expected 32-bit ELF");
@@ -142,7 +149,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
         let section_range = lowest_address..=highest_address;
         let name = section.name().unwrap_or("<unknown>");
 
-        if ram_range.contains(section_range.end()) {
+        if ram_range.contains(&(*section_range.end() as u64)) {
             log::debug!("section `{}` is in RAM at {:#010X?}", name, section_range);
 
             if section_range.contains(stack_range.end()) {
@@ -159,7 +166,7 @@ fn extract_stack_info(elf: &Elf, ram_range: &Range<u32>) -> Option<StackInfo> {
 
     log::debug!("valid SP range: {:#010X?}", stack_range);
     Some(StackInfo {
-        data_below_stack: *stack_range.start() > ram_range.start,
+        data_below_stack: *stack_range.start() as u64 > ram_range.start,
         range: stack_range,
     })
 }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -65,14 +65,13 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
     let matches = match core_type {
         CoreType::Armv6m => target == "thumbv6m-none-eabi",
         CoreType::Armv7m => target == "thumbv7m-none-eabi",
-        CoreType::Armv7a => target == "thumbv7a-none-eabi",
         CoreType::Armv7em => target == "thumbv7em-none-eabi" || target == "thumbv7em-none-eabihf",
         CoreType::Armv8m => {
             target == "thumbv8m.base-none-eabi"
                 || target == "thumbv8m.main-none-eabi"
                 || target == "thumbv8m.main-none-eabihf"
         }
-        CoreType::Armv8a => {
+        CoreType::Armv7a | CoreType::Armv8a => {
             log::warn!("Unsupported architecture ({core_type:?}");
             return;
         }
@@ -88,14 +87,13 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
     let recommendation = match core_type {
         CoreType::Armv6m => "must be 'thumbv6m-none-eabi'",
         CoreType::Armv7m => "should be 'thumbv7m-none-eabi'",
-        CoreType::Armv7a => "should be 'thumbv7a-none-eabi'",
         CoreType::Armv7em => {
             "should be 'thumbv7em-none-eabi' (no FPU) or 'thumbv7em-none-eabihf' (with FPU)"
         }
         CoreType::Armv8m => {
             "should be 'thumbv8m.base-none-eabi' (M23), 'thumbv8m.main-none-eabi' (M33 no FPU), or 'thumbv8m.main-none-eabihf' (M33 with FPU)"
         }
-        CoreType::Armv8a => unreachable!(),
+        CoreType::Armv7a | CoreType::Armv8a => unreachable!(),
         CoreType::Riscv => unreachable!(),
     };
     log::warn!("Compilation target ({target}) and core type ({core_type:?}) do not match. Your compilation target {recommendation}.");


### PR DESCRIPTION
This patch doesn't implement 64-bit support, but only inserts
conversions from u32 to u64 where necessary.