### PR TITLE
Fix `fn round_up`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#330] Fix `fn round_up`
 - [#329] Update probe-rs to 0.13.0 (does not yet implement 64-bit support)
 - [#328] Simplify, by capturing identifiers in logging macros
 - [#326] Make use of i/o locking being static since rust `1.61`.
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
 
+[#330]: https://github.com/knurling-rs/probe-run/pull/330
 [#329]: https://github.com/knurling-rs/probe-run/pull/329
 [#328]: https://github.com/knurling-rs/probe-run/pull/328
 [#326]: https://github.com/knurling-rs/probe-run/pull/326

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -169,6 +169,7 @@ impl Canary {
     }
 }
 
+/// Rounds up to the next multiple of `k` that is greater or equal to `n`.
 fn round_up(n: u32, k: u32) -> u32 {
     let rem = n % k;
     if rem == 0 {

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -174,7 +174,7 @@ fn round_up(n: u32, k: u32) -> u32 {
     if rem == 0 {
         n
     } else {
-        n + 4 - rem
+        n + k - rem
     }
 }
 


### PR DESCRIPTION
It was hardcoding `k` as `4`. This PR changes the fn to actually use `k`.
This resultet in no problem so far, because it was only used with `k=4`.