### PR TITLE
Clean up `enum Outcome`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#333] Clean up `enum Outcome`
 - [#331] Refactor stack painting
 - [#330] Fix `fn round_up`
 - [#329] Update probe-rs to 0.13.0 (does not yet implement 64-bit support)
@@ -18,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
 
+[#333]: https://github.com/knurling-rs/probe-run/pull/333
 [#331]: https://github.com/knurling-rs/probe-run/pull/331
 [#330]: https://github.com/knurling-rs/probe-run/pull/330
 [#329]: https://github.com/knurling-rs/probe-run/pull/329

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -92,29 +92,22 @@ pub(crate) enum Outcome {
     HardFault,
     Ok,
     StackOverflow,
-    CtrlC, // control-c was pressed
+    /// Control-C was pressed
+    CtrlC,
 }
 
 impl Outcome {
     pub(crate) fn log(&self) {
         match self {
-            Outcome::StackOverflow => {
-                log::error!("the program has overflowed its stack");
-            }
-            Outcome::HardFault => {
-                log::error!("the program panicked");
-            }
-            Outcome::Ok => {
-                log::info!("device halted without error");
-            }
-            Outcome::CtrlC => {
-                log::info!("device halted by user");
-            }
+            Outcome::StackOverflow => log::error!("the program has overflowed its stack"),
+            Outcome::HardFault => log::error!("the program panicked"),
+            Outcome::Ok => log::info!("device halted without error"),
+            Outcome::CtrlC => log::info!("device halted by user"),
         }
     }
 }
 
-/// Converts `Outcome` to an exit code.
+// Convert `Outcome` to an exit code.
 impl From<Outcome> for i32 {
     fn from(outcome: Outcome) -> i32 {
         match outcome {


### PR DESCRIPTION
A small drive-by PR to clean up `enum Outcome` in the `backtrace` module.