### PR TITLE
Test round up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-- [#xxx] Add unit tests for `fn round_up`
+- [#335] Add unit tests for `fn round_up`
 - [#334] Simplify snapshot tests
 - [#333] Clean up `enum Outcome`
 - [#331] Refactor stack painting
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
 
-[#xxx]: https://github.com/knurling-rs/probe-run/pull/xxx
+[#335]: https://github.com/knurling-rs/probe-run/pull/335
 [#334]: https://github.com/knurling-rs/probe-run/pull/334
 [#333]: https://github.com/knurling-rs/probe-run/pull/333
 [#331]: https://github.com/knurling-rs/probe-run/pull/331

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#xxx] Add unit tests for `fn round_up`
 - [#334] Simplify snapshot tests
 - [#333] Clean up `enum Outcome`
 - [#331] Refactor stack painting
@@ -20,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - [#314] Clarify documentation in README
 - [#293] Update snapshot tests to new TRACE output
 
+[#xxx]: https://github.com/knurling-rs/probe-run/pull/xxx
 [#334]: https://github.com/knurling-rs/probe-run/pull/334
 [#333]: https://github.com/knurling-rs/probe-run/pull/333
 [#331]: https://github.com/knurling-rs/probe-run/pull/331

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -297,3 +297,22 @@ fn prepare_subroutine<const N: usize>(
 
     Ok(previous_pc)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(2, 4, 4)]
+    #[case(4, 4, 4)]
+    #[case(6, 4, 8)]
+    #[case(8, 4, 8)]
+    #[case::odd(5, 3, 6)]
+    #[should_panic]
+    #[case::div_zero(4, 0, 0)]
+    fn test_round_up(#[case] n: u32, #[case] k: u32, #[case] res: u32) {
+        assert_eq!(round_up(n, k), res);
+    }
+}


### PR DESCRIPTION
Add unit tests for:
```rust
/// Rounds up to the next multiple of `k` that is greater or equal to `n`.
fn round_up(n: u32, k: u32) -> u32 { /* */ }
```