### PR TITLE
Replace `pub(crate)` with `pub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-- [#xxx] Mark `v0.3.4` as released in `CHANGELOG.md`
+- [#344] Replace `pub(crate)` with `pub`
+- [#343] Mark `v0.3.4` as released in `CHANGELOG.md`
 
-[#xxx]: https://github.com/knurling-rs/probe-run/pull/xxx
+[#344]: https://github.com/knurling-rs/probe-run/pull/344
+[#343]: https://github.com/knurling-rs/probe-run/pull/343
 
 ## [v0.3.4] - 2022-08-10
 

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -10,7 +10,7 @@ mod symbolicate;
 mod unwind;
 
 #[derive(PartialEq, Eq)]
-pub(crate) enum BacktraceOptions {
+pub enum BacktraceOptions {
     Auto,
     Never,
     Always,
@@ -27,17 +27,17 @@ impl From<&String> for BacktraceOptions {
     }
 }
 
-pub(crate) struct Settings<'p> {
-    pub(crate) current_dir: &'p Path,
-    pub(crate) backtrace: BacktraceOptions,
-    pub(crate) panic_present: bool,
-    pub(crate) backtrace_limit: u32,
-    pub(crate) shorten_paths: bool,
-    pub(crate) include_addresses: bool,
+pub struct Settings<'p> {
+    pub current_dir: &'p Path,
+    pub backtrace: BacktraceOptions,
+    pub panic_present: bool,
+    pub backtrace_limit: u32,
+    pub shorten_paths: bool,
+    pub include_addresses: bool,
 }
 
 /// (virtually) unwinds the target's program and prints its backtrace
-pub(crate) fn print(
+pub fn print(
     core: &mut Core,
     elf: &Elf,
     active_ram_region: &Option<RamRegion>,
@@ -88,7 +88,7 @@ pub(crate) fn print(
 
 /// Target program outcome
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum Outcome {
+pub enum Outcome {
     HardFault,
     Ok,
     StackOverflow,
@@ -97,7 +97,7 @@ pub(crate) enum Outcome {
 }
 
 impl Outcome {
-    pub(crate) fn log(&self) {
+    pub fn log(&self) {
         match self {
             Outcome::StackOverflow => log::error!("the program has overflowed its stack"),
             Outcome::HardFault => log::error!("the program panicked"),

--- a/src/backtrace/pp.rs
+++ b/src/backtrace/pp.rs
@@ -13,7 +13,7 @@ use crate::dep;
 use super::{symbolicate::Frame, Settings};
 
 /// Pretty prints processed backtrace frames up to `backtrace_limit`
-pub(crate) fn backtrace(frames: &[Frame], settings: &Settings) -> io::Result<()> {
+pub fn backtrace(frames: &[Frame], settings: &Settings) -> io::Result<()> {
     let mut stderr = io::stderr().lock();
     writeln!(stderr, "{}", "stack backtrace:".dimmed())?;
 

--- a/src/backtrace/symbolicate.rs
+++ b/src/backtrace/symbolicate.rs
@@ -14,7 +14,7 @@ use crate::{cortexm, elf::Elf};
 
 use super::unwind::RawFrame;
 
-pub(crate) fn frames(raw_frames: &[RawFrame], current_dir: &Path, elf: &Elf) -> Vec<Frame> {
+pub fn frames(raw_frames: &[RawFrame], current_dir: &Path, elf: &Elf) -> Vec<Frame> {
     let mut frames = vec![];
 
     let symtab = elf.symbol_map();
@@ -43,17 +43,17 @@ pub(crate) fn frames(raw_frames: &[RawFrame], current_dir: &Path, elf: &Elf) -> 
 
 /// Processed frame
 #[derive(Debug)]
-pub(crate) enum Frame {
+pub enum Frame {
     Exception,
     Subroutine(Subroutine),
 }
 
 /// "Symbolicated" and de-inlined subroutine frame
 #[derive(Debug)]
-pub(crate) struct Subroutine {
-    pub(crate) name: Option<String>,
-    pub(crate) pc: u32,
-    pub(crate) location: Option<Location>,
+pub struct Subroutine {
+    pub name: Option<String>,
+    pub pc: u32,
+    pub location: Option<Location>,
 }
 
 type A2lContext = addr2line::Context<EndianReader<RunTimeEndian, Rc<[u8]>>>;
@@ -168,9 +168,9 @@ fn name_from_symtab(pc: u32, symtab: &SymbolMap<SymbolMapName>) -> Option<String
 }
 
 #[derive(Debug)]
-pub(crate) struct Location {
-    pub(crate) column: Option<u32>,
-    pub(crate) path_is_relative: bool,
-    pub(crate) line: u32,
-    pub(crate) path: PathBuf,
+pub struct Location {
+    pub column: Option<u32>,
+    pub path_is_relative: bool,
+    pub line: u32,
+    pub path: PathBuf,
 }

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -27,7 +27,7 @@ fn missing_debug_info(pc: u32) -> String {
 ///
 /// This returns as much info as could be collected, even if the collection is interrupted by an error.
 /// If an error occurred during processing, it is stored in `Output::processing_error`.
-pub(crate) fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamRegion>) -> Output {
+pub fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamRegion>) -> Output {
     let mut output = Output {
         corrupted: true,
         outcome: Outcome::Ok,
@@ -171,24 +171,24 @@ fn check_hard_fault(
 
 #[derive(Debug)]
 pub struct Output {
-    pub(crate) corrupted: bool,
-    pub(crate) outcome: Outcome,
-    pub(crate) raw_frames: Vec<RawFrame>,
+    pub corrupted: bool,
+    pub outcome: Outcome,
+    pub raw_frames: Vec<RawFrame>,
     /// Will be `Some` if an error occured while putting together the output.
     /// `outcome` and `raw_frames` will contain all info collected until the error occurred.
-    pub(crate) processing_error: Option<anyhow::Error>,
+    pub processing_error: Option<anyhow::Error>,
 }
 
 /// Backtrace frame prior to 'symbolication'
 #[derive(Debug)]
-pub(crate) enum RawFrame {
+pub enum RawFrame {
     Subroutine { pc: u32 },
     Exception,
 }
 
 impl RawFrame {
     /// Returns `true` if the raw_frame is [`Exception`].
-    pub(crate) fn is_exception(&self) -> bool {
+    pub fn is_exception(&self) -> bool {
         matches!(self, Self::Exception)
     }
 }

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -39,7 +39,7 @@ const CANARY_U32: u32 = u32::from_le_bytes([CANARY_U8, CANARY_U8, CANARY_U8, CAN
 /// "touched" (any of its bytes != `CANARY_U8`) then that is considered to be a *potential* stack
 /// overflow.
 #[derive(Clone, Copy)]
-pub(crate) struct Canary {
+pub struct Canary {
     address: u32,
     size: usize,
     stack_available: u32,
@@ -49,7 +49,7 @@ pub(crate) struct Canary {
 
 impl Canary {
     /// Decide if and where to place the stack canary.
-    pub(crate) fn install(
+    pub fn install(
         sess: &mut Session,
         target_info: &TargetInfo,
         elf: &Elf,
@@ -113,7 +113,7 @@ impl Canary {
     }
 
     /// Detect if the stack canary was touched.
-    pub(crate) fn touched(self, core: &mut probe_rs::Core, elf: &Elf) -> anyhow::Result<bool> {
+    pub fn touched(self, core: &mut probe_rs::Core, elf: &Elf) -> anyhow::Result<bool> {
         let size_kb = self.size as f64 / 1024.0;
         if self.measure_stack {
             log::info!("reading {size_kb:.2} KiB of RAM for stack usage estimation");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ const EXIT_SUCCESS: i32 = 0;
 /// A Cargo runner for microcontrollers.
 #[derive(StructOpt)]
 #[structopt(name = "probe-run", setting = AppSettings::TrailingVarArg)]
-pub(crate) struct Opts {
+pub struct Opts {
     /// List supported chips and exit.
     #[structopt(long)]
     list_chips: bool,
@@ -29,15 +29,15 @@ pub(crate) struct Opts {
 
     /// Path to chip description file, in YAML format.
     #[structopt(long)]
-    pub(crate) chip_description_path: Option<PathBuf>,
+    pub chip_description_path: Option<PathBuf>,
 
     /// The probe to use (eg. `VID:PID`, `VID:PID:Serial`, or just `Serial`).
     #[structopt(long, env = "PROBE_RUN_PROBE")]
-    pub(crate) probe: Option<String>,
+    pub probe: Option<String>,
 
     /// The probe clock frequency in kHz
     #[structopt(long)]
-    pub(crate) speed: Option<u32>,
+    pub speed: Option<u32>,
 
     /// Path to an ELF firmware file.
     #[structopt(name = "ELF", parse(from_os_str), required_unless_one(&["list-chips", "list-probes", "version"]))]
@@ -45,15 +45,15 @@ pub(crate) struct Opts {
 
     /// Skip writing the application binary to flash.
     #[structopt(long, conflicts_with = "defmt")]
-    pub(crate) no_flash: bool,
+    pub no_flash: bool,
 
     /// Connect to device when NRST is pressed.
     #[structopt(long)]
-    pub(crate) connect_under_reset: bool,
+    pub connect_under_reset: bool,
 
     /// Enable more verbose output.
     #[structopt(short, long, parse(from_occurrences))]
-    pub(crate) verbose: u32,
+    pub verbose: u32,
 
     /// Prints version information
     #[structopt(short = "V", long)]
@@ -61,33 +61,33 @@ pub(crate) struct Opts {
 
     /// Disable or enable backtrace (auto in case of panic or stack overflow).
     #[structopt(long, default_value = "auto")]
-    pub(crate) backtrace: String,
+    pub backtrace: String,
 
     /// Configure the number of lines to print before a backtrace gets cut off
     #[structopt(long, default_value = "50")]
-    pub(crate) backtrace_limit: u32,
+    pub backtrace_limit: u32,
 
     /// Whether to shorten paths (e.g. to crates.io dependencies) in backtraces and defmt logs
     #[structopt(long)]
-    pub(crate) shorten_paths: bool,
+    pub shorten_paths: bool,
 
     /// Whether to measure the program's stack consumption.
     #[structopt(long)]
-    pub(crate) measure_stack: bool,
+    pub measure_stack: bool,
 
     #[structopt(long)]
-    pub(crate) json: bool,
+    pub json: bool,
 
     /// Disable use of double buffering while downloading flash
     #[structopt(long = "disable-double-buffering")]
-    pub(crate) disable_double_buffering: bool,
+    pub disable_double_buffering: bool,
 
     /// Arguments passed after the ELF file path are discarded
     #[structopt(name = "REST")]
     _rest: Vec<String>,
 }
 
-pub(crate) fn handle_arguments() -> anyhow::Result<i32> {
+pub fn handle_arguments() -> anyhow::Result<i32> {
     let opts: Opts = Opts::from_args();
     let verbose = opts.verbose;
 

--- a/src/cortexm.rs
+++ b/src/cortexm.rs
@@ -4,50 +4,50 @@ use std::{mem, ops::Range};
 
 use gimli::LittleEndian;
 
-pub(crate) const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
+pub const ADDRESS_SIZE: u8 = mem::size_of::<u32>() as u8;
 
 /// According to Armv8-M Architecture Reference Manual, the most significant 8 bits are `0xFF` to
 /// indicate `EXC_RETURN`, the rest is either reserved or contains data.
-pub(crate) const EXC_RETURN_MARKER: u32 = 0xFF00_0000;
+pub const EXC_RETURN_MARKER: u32 = 0xFF00_0000;
 
-pub(crate) const EXC_RETURN_FTYPE_MASK: u32 = 1 << 4;
+pub const EXC_RETURN_FTYPE_MASK: u32 = 1 << 4;
 
-pub(crate) const ENDIANNESS: LittleEndian = LittleEndian;
-pub(crate) type Endianness = LittleEndian;
+pub const ENDIANNESS: LittleEndian = LittleEndian;
+pub type Endianness = LittleEndian;
 
 const THUMB_BIT: u32 = 1;
 // According to the ARM Cortex-M Reference Manual RAM memory must be located in this address range
 // (vendors still place e.g. Core-Coupled RAM outside this address range)
-pub(crate) const VALID_RAM_ADDRESS: Range<u32> = 0x2000_0000..0x4000_0000;
+pub const VALID_RAM_ADDRESS: Range<u32> = 0x2000_0000..0x4000_0000;
 
-pub(crate) fn clear_thumb_bit(addr: u32) -> u32 {
+pub fn clear_thumb_bit(addr: u32) -> u32 {
     addr & !THUMB_BIT
 }
 
 /// Checks if PC is the HardFault handler
 // XXX may want to relax this to cover the whole PC range of the `HardFault` handler
-pub(crate) fn is_hard_fault(pc: u32, vector_table: &VectorTable) -> bool {
+pub fn is_hard_fault(pc: u32, vector_table: &VectorTable) -> bool {
     subroutine_eq(pc, vector_table.hard_fault)
 }
 
-pub(crate) fn is_thumb_bit_set(addr: u32) -> bool {
+pub fn is_thumb_bit_set(addr: u32) -> bool {
     addr & THUMB_BIT == THUMB_BIT
 }
 
-pub(crate) fn set_thumb_bit(addr: u32) -> u32 {
+pub fn set_thumb_bit(addr: u32) -> u32 {
     addr | THUMB_BIT
 }
 
 /// Checks if two subroutine addresses are equivalent by first clearing their `THUMB_BIT`
-pub(crate) fn subroutine_eq(addr1: u32, addr2: u32) -> bool {
+pub fn subroutine_eq(addr1: u32, addr2: u32) -> bool {
     addr1 & !THUMB_BIT == addr2 & !THUMB_BIT
 }
 
 /// The contents of the vector table
 #[derive(Debug)]
-pub(crate) struct VectorTable {
+pub struct VectorTable {
     // entry 0
-    pub(crate) initial_stack_pointer: u32,
+    pub initial_stack_pointer: u32,
     // entry 3: HardFault handler
-    pub(crate) hard_fault: u32,
+    pub hard_fault: u32,
 }

--- a/src/dep/cratesio.rs
+++ b/src/dep/cratesio.rs
@@ -3,14 +3,14 @@ use std::path::{self, Component, Path as StdPath, PathBuf};
 use colored::Colorize as _;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct Path<'p> {
+pub struct Path<'p> {
     registry_prefix: PathBuf,
     crate_name_version: &'p str,
     path: &'p StdPath,
 }
 
 impl<'p> Path<'p> {
-    pub(crate) fn from_std_path(path: &'p StdPath) -> Option<Self> {
+    pub fn from_std_path(path: &'p StdPath) -> Option<Self> {
         if !path.is_absolute() {
             return None;
         }
@@ -49,7 +49,7 @@ impl<'p> Path<'p> {
         })
     }
 
-    pub(crate) fn format_short(&self) -> String {
+    pub fn format_short(&self) -> String {
         format!(
             "[{}]{}{}",
             self.crate_name_version,
@@ -58,7 +58,7 @@ impl<'p> Path<'p> {
         )
     }
 
-    pub(crate) fn format_highlight(&self) -> String {
+    pub fn format_highlight(&self) -> String {
         format!(
             "{}{sep}{}{sep}{}",
             self.registry_prefix.display().to_string().dimmed(),

--- a/src/dep/mod.rs
+++ b/src/dep/mod.rs
@@ -11,7 +11,7 @@ mod rust_std;
 mod rustc;
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum Path<'p> {
+pub enum Path<'p> {
     Cratesio(cratesio::Path<'p>),
     /// Path into `rust-std` component
     RustStd(rust_std::Path<'p>),
@@ -21,7 +21,7 @@ pub(crate) enum Path<'p> {
 }
 
 impl<'p> Path<'p> {
-    pub(crate) fn from_std_path(path: &'p StdPath) -> Self {
+    pub fn from_std_path(path: &'p StdPath) -> Self {
         if let Some(rust_std) = rust_std::Path::from_std_path(path) {
             Self::RustStd(rust_std)
         } else if let Some(rustc) = rustc::Path::from_std_path(path) {
@@ -33,7 +33,7 @@ impl<'p> Path<'p> {
         }
     }
 
-    pub(crate) fn format_short(&self) -> String {
+    pub fn format_short(&self) -> String {
         match self {
             Path::Cratesio(cratesio) => cratesio.format_short(),
             Path::RustStd(rust_std) => rust_std.format_short(),
@@ -42,7 +42,7 @@ impl<'p> Path<'p> {
         }
     }
 
-    pub(crate) fn format_highlight(&self) -> String {
+    pub fn format_highlight(&self) -> String {
         match self {
             Path::Cratesio(cratesio) => cratesio.format_highlight(),
             Path::RustStd(rust_std) => rust_std.format_highlight(),

--- a/src/dep/rust_repo.rs
+++ b/src/dep/rust_repo.rs
@@ -4,13 +4,13 @@ use colored::Colorize as _;
 
 /// Representation of a rust-lang/rust repo path
 #[derive(Debug, PartialEq)]
-pub(crate) enum Path<'p> {
+pub enum Path<'p> {
     One52(One52Path<'p>),
     Verbatim(&'p StdPath),
 }
 
 impl<'p> Path<'p> {
-    pub(crate) fn from_std_path(path: &'p StdPath) -> Self {
+    pub fn from_std_path(path: &'p StdPath) -> Self {
         if let Some(path) = One52Path::from_std_path(path) {
             Path::One52(path)
         } else {
@@ -18,14 +18,14 @@ impl<'p> Path<'p> {
         }
     }
 
-    pub(crate) fn format(&self) -> String {
+    pub fn format(&self) -> String {
         match self {
             Path::One52(path) => path.format(),
             Path::Verbatim(path) => path.display().to_string(),
         }
     }
 
-    pub(crate) fn format_highlight(&self) -> String {
+    pub fn format_highlight(&self) -> String {
         match self {
             Path::One52(path) => path.format_highlight(),
             Path::Verbatim(path) => path.display().to_string(),
@@ -35,10 +35,10 @@ impl<'p> Path<'p> {
 
 /// rust-lang/repo path format as of 1.52 e.g. "library/core/src/panic.rs"
 #[derive(Debug, PartialEq)]
-pub(crate) struct One52Path<'p> {
-    pub(crate) library: &'p str,
-    pub(crate) crate_name: &'p str,
-    pub(crate) path: &'p StdPath,
+pub struct One52Path<'p> {
+    pub library: &'p str,
+    pub crate_name: &'p str,
+    pub path: &'p StdPath,
 }
 
 impl<'p> One52Path<'p> {

--- a/src/dep/rust_std.rs
+++ b/src/dep/rust_std.rs
@@ -9,7 +9,7 @@ use super::rust_repo;
 mod toolchain;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct Path<'p> {
+pub struct Path<'p> {
     rustup_prefix: PathBuf,
     toolchain: Toolchain<'p>,
     rust_std_prefix: PathBuf,
@@ -17,7 +17,7 @@ pub(crate) struct Path<'p> {
 }
 
 impl<'p> Path<'p> {
-    pub(crate) fn from_std_path(path: &'p StdPath) -> Option<Self> {
+    pub fn from_std_path(path: &'p StdPath) -> Option<Self> {
         if !path.is_absolute() {
             return None;
         }
@@ -59,7 +59,7 @@ impl<'p> Path<'p> {
         })
     }
 
-    pub(crate) fn format_short(&self) -> String {
+    pub fn format_short(&self) -> String {
         format!(
             "[{}]{}{}",
             self.toolchain.format_short(),
@@ -68,7 +68,7 @@ impl<'p> Path<'p> {
         )
     }
 
-    pub(crate) fn format_highlight(&self) -> String {
+    pub fn format_highlight(&self) -> String {
         format!(
             "{}{sep}{}{sep}{}{sep}{}",
             self.rustup_prefix.display().to_string().dimmed(),

--- a/src/dep/rust_std/toolchain.rs
+++ b/src/dep/rust_std/toolchain.rs
@@ -3,13 +3,13 @@ use std::borrow::Cow;
 use colored::Colorize;
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum Toolchain<'p> {
+pub enum Toolchain<'p> {
     One52(One52<'p>),
     Verbatim(&'p str),
 }
 
 impl<'p> Toolchain<'p> {
-    pub(crate) fn from_str(input: &str) -> Toolchain {
+    pub fn from_str(input: &str) -> Toolchain {
         if let Some(toolchain) = One52::from_str(input) {
             Toolchain::One52(toolchain)
         } else {
@@ -17,14 +17,14 @@ impl<'p> Toolchain<'p> {
         }
     }
 
-    pub(crate) fn format_highlight(&self) -> Cow<str> {
+    pub fn format_highlight(&self) -> Cow<str> {
         match self {
             Toolchain::One52(toolchain) => toolchain.format_highlight().into(),
             Toolchain::Verbatim(toolchain) => Cow::Borrowed(toolchain),
         }
     }
 
-    pub(crate) fn format_short(&self) -> Cow<str> {
+    pub fn format_short(&self) -> Cow<str> {
         match self {
             Toolchain::One52(toolchain) => toolchain.format_short(),
             Toolchain::Verbatim(toolchain) => Cow::Borrowed(toolchain),
@@ -33,9 +33,9 @@ impl<'p> Toolchain<'p> {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct One52<'p> {
-    pub(crate) channel: Channel<'p>,
-    pub(crate) host: &'p str,
+pub struct One52<'p> {
+    pub channel: Channel<'p>,
+    pub host: &'p str,
 }
 
 impl<'p> One52<'p> {
@@ -114,7 +114,7 @@ impl<'p> One52<'p> {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum Channel<'p> {
+pub enum Channel<'p> {
     Beta,
     Nightly { date: Option<&'p str> },
     Stable,

--- a/src/dep/rustc.rs
+++ b/src/dep/rustc.rs
@@ -5,13 +5,13 @@ use colored::Colorize;
 use super::rust_repo;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct Path<'p> {
+pub struct Path<'p> {
     rustc_prefix: PathBuf,
     rust_repo_path: rust_repo::Path<'p>,
 }
 
 impl<'p> Path<'p> {
-    pub(crate) fn from_std_path(path: &'p StdPath) -> Option<Self> {
+    pub fn from_std_path(path: &'p StdPath) -> Option<Self> {
         if !path.is_absolute() {
             return None;
         }
@@ -43,7 +43,7 @@ impl<'p> Path<'p> {
         })
     }
 
-    pub(crate) fn format_short(&self) -> String {
+    pub fn format_short(&self) -> String {
         format!(
             "[rust]{}{}",
             path::MAIN_SEPARATOR,
@@ -51,7 +51,7 @@ impl<'p> Path<'p> {
         )
     }
 
-    pub(crate) fn format_highlight(&self) -> String {
+    pub fn format_highlight(&self) -> String {
         format!(
             "{}{}{}",
             self.rustc_prefix.display().to_string().dimmed(),

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -8,23 +8,20 @@ use object::{
 
 use crate::cortexm;
 
-pub(crate) struct Elf<'file> {
+pub struct Elf<'file> {
     elf: ObjectFile<'file>,
     symbols: Symbols,
 
-    pub(crate) debug_frame: DebugFrame<'file>,
-    pub(crate) defmt_locations: Option<Locations>,
-    pub(crate) defmt_table: Option<Table>,
-    pub(crate) elf_path: &'file Path,
-    pub(crate) live_functions: HashSet<&'file str>,
-    pub(crate) vector_table: cortexm::VectorTable,
+    pub debug_frame: DebugFrame<'file>,
+    pub defmt_locations: Option<Locations>,
+    pub defmt_table: Option<Table>,
+    pub elf_path: &'file Path,
+    pub live_functions: HashSet<&'file str>,
+    pub vector_table: cortexm::VectorTable,
 }
 
 impl<'file> Elf<'file> {
-    pub(crate) fn parse(
-        elf_bytes: &'file [u8],
-        elf_path: &'file Path,
-    ) -> Result<Self, anyhow::Error> {
+    pub fn parse(elf_bytes: &'file [u8], elf_path: &'file Path) -> Result<Self, anyhow::Error> {
         let elf = ObjectFile::parse(elf_bytes)?;
 
         let live_functions = extract_live_functions(&elf)?;
@@ -49,15 +46,15 @@ impl<'file> Elf<'file> {
         })
     }
 
-    pub(crate) fn main_fn_address(&self) -> u32 {
+    pub fn main_fn_address(&self) -> u32 {
         self.symbols.main_fn_address
     }
 
-    pub(crate) fn program_uses_heap(&self) -> bool {
+    pub fn program_uses_heap(&self) -> bool {
         self.symbols.program_uses_heap
     }
 
-    pub(crate) fn rtt_buffer_address(&self) -> Option<u32> {
+    pub fn rtt_buffer_address(&self) -> Option<u32> {
         self.symbols.rtt_buffer_address
     }
 }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -9,7 +9,7 @@ const NO_PROBE_FOUND_ERR: &str = "no probe was found.\n
 Common reasons for this are faulty cables or missing permissions.
 For detailed instructions, visit: https://github.com/knurling-rs/probe-run/tree/2f138c3#troubleshooting";
 
-pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
+pub fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     let all_probes = Probe::list_all();
     let filtered_probes = if let Some(probe_opt) = opts.probe.as_deref() {
         let selector = probe_opt.parse()?;
@@ -39,7 +39,7 @@ pub(crate) fn open(opts: &cli::Opts) -> Result<Probe, anyhow::Error> {
     Ok(probe)
 }
 
-pub(crate) fn print(probes: &[DebugProbeInfo]) {
+pub fn print(probes: &[DebugProbeInfo]) {
     if !probes.is_empty() {
         println!("the following probes were found:");
         probes

--- a/src/stacked.rs
+++ b/src/stacked.rs
@@ -4,7 +4,7 @@ use probe_rs::{Core, MemoryInterface};
 
 /// Registers stacked on exception entry.
 #[derive(Debug)]
-pub(crate) struct Stacked {
+pub struct Stacked {
     // also pushed onto the stack but we don't need to read them
     // r0: u32,
     // r1: u32,

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -13,21 +13,21 @@ use probe_rs::{
 
 use crate::elf::Elf;
 
-pub(crate) struct TargetInfo {
-    pub(crate) probe_target: probe_rs::Target,
+pub struct TargetInfo {
+    pub probe_target: probe_rs::Target,
     /// RAM region that contains the call stack
-    pub(crate) active_ram_region: Option<RamRegion>,
-    pub(crate) stack_info: Option<StackInfo>,
+    pub active_ram_region: Option<RamRegion>,
+    pub stack_info: Option<StackInfo>,
 }
 
-pub(crate) struct StackInfo {
+pub struct StackInfo {
     /// Valid values of the stack pointer (that don't collide with other data).
-    pub(crate) range: RangeInclusive<u32>,
-    pub(crate) data_below_stack: bool,
+    pub range: RangeInclusive<u32>,
+    pub data_below_stack: bool,
 }
 
 impl TargetInfo {
-    pub(crate) fn new(chip: &str, elf: &Elf) -> anyhow::Result<Self> {
+    pub fn new(chip: &str, elf: &Elf) -> anyhow::Result<Self> {
         let probe_target = probe_rs::config::get_target_by_name(chip)?;
         check_processor_target_compatability(&probe_target.cores, elf.elf_path);
 


### PR DESCRIPTION
Since `probe-run` is a binary crate, `pub` has the same effect as `pub(crate)`.