### PR TITLE
Add PROBE_RUN_SPEED env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#349] Add `PROBE_RUN_SPEED` env variable
 - [#345] Update dev-dependency `serial_test`
 - [#344] Replace `pub(crate)` with `pub`
 - [#343] Mark `v0.3.4` as released in `CHANGELOG.md`
 
+[#349]: https://github.com/knurling-rs/probe-run/pull/349
 [#345]: https://github.com/knurling-rs/probe-run/pull/345
 [#344]: https://github.com/knurling-rs/probe-run/pull/344
 [#343]: https://github.com/knurling-rs/probe-run/pull/343

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub struct Opts {
     pub probe: Option<String>,
 
     /// The probe clock frequency in kHz
-    #[structopt(long)]
+    #[structopt(long, env = "PROBE_RUN_SPEED")]
     pub speed: Option<u32>,
 
     /// Path to an ELF firmware file.


### PR DESCRIPTION
- Useful when wanting to set the SWD speed in your .cargo/config.toml