### PR TITLE
Update to `clap 4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#357] Update to `clap 4.0`
 - [#349] Add `PROBE_RUN_SPEED` env variable
 - [#345] Update dev-dependency `serial_test`
 - [#344] Replace `pub(crate)` with `pub`
 - [#343] Mark `v0.3.4` as released in `CHANGELOG.md`
-- [#353] add option to verify written flash
+- [#353] Add option to verify written flash
 
+[#357]: https://github.com/knurling-rs/probe-run/pull/357
 [#349]: https://github.com/knurling-rs/probe-run/pull/349
 [#345]: https://github.com/knurling-rs/probe-run/pull/345
 [#344]: https://github.com/knurling-rs/probe-run/pull/344

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,17 +131,39 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "3943ff31339d6d148b4e9cfb9b1eb0f814989ed21dfede3c2d2e11f3d9497f60"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -367,12 +389,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -592,6 +611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +727,7 @@ version = "0.3.4"
 dependencies = [
  "addr2line",
  "anyhow",
+ "clap",
  "colored",
  "defmt-decoder",
  "dirs",
@@ -718,7 +744,6 @@ dependencies = [
  "rstest",
  "serial_test",
  "signal-hook",
- "structopt",
 ]
 
 [[package]]
@@ -985,33 +1010,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svg"
@@ -1037,6 +1038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,15 +1054,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1082,28 +1083,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1186,6 +1169,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ addr2line = { version = "0.18", default-features = false, features = [
     "cpp_demangle",
 ] }
 anyhow = "1"
+clap = { version = "4.0", features = ["derive", "env"] }
 colored = "2"
 defmt-decoder = { version = "=0.3.3", features = ["unstable"] }
 gimli = { version = "0.26", default-features = false }
@@ -27,7 +28,6 @@ object = { version = "0.29", default-features = false }
 probe-rs = "0.13"
 probe-rs-rtt = "0.13"
 signal-hook = "0.3"
-structopt = "0.3"
 
 [dev-dependencies]
 dirs = "4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Opts {
     pub backtrace_limit: u32,
 
     /// The chip to program.
-    #[arg(long, required = true, conflicts_with_all = HELPER, env = "PROBE_RUN_CHIP")]
+    #[arg(long, required = true, conflicts_with_all = HELPER_CMDS, env = "PROBE_RUN_CHIP")]
     chip: Option<String>,
 
     /// Path to chip description file, in YAML format.
@@ -40,7 +40,7 @@ pub struct Opts {
     pub disable_double_buffering: bool,
 
     /// Path to an ELF firmware file.
-    #[arg(required = true, conflicts_with_all = HELPER)]
+    #[arg(required = true, conflicts_with_all = HELPER_CMDS)]
     elf: Option<PathBuf>,
 
     /// Output logs a structured json.
@@ -97,7 +97,7 @@ pub struct Opts {
 }
 
 /// Helper commands, which will not execute probe-run normally.
-const HELPER: [&str; 3] = ["list_chips", "list_probes", "version"];
+const HELPER_CMDS: [&str; 3] = ["list_chips", "list_probes", "version"];
 
 pub fn handle_arguments() -> anyhow::Result<i32> {
     let opts = Opts::parse();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Opts {
     list_probes: bool,
 
     /// The chip to program.
-    #[arg(long, required_unless_present_any(&["list_chips", "list_probes", "version"]), env = "PROBE_RUN_CHIP")]
+    #[arg(long, required_unless_present_any(HELPER), env = "PROBE_RUN_CHIP")]
     chip: Option<String>,
 
     /// Path to chip description file, in YAML format.
@@ -40,7 +40,7 @@ pub struct Opts {
     pub speed: Option<u32>,
 
     /// Path to an ELF firmware file.
-    #[arg(name = "ELF", required_unless_present_any(&["list_chips", "list_probes", "version"]))]
+    #[arg(required_unless_present_any(HELPER))]
     elf: Option<PathBuf>,
 
     /// Skip writing the application binary to flash.
@@ -94,6 +94,9 @@ pub struct Opts {
     #[arg(name = "REST", trailing_var_arg = true)]
     _rest: Vec<String>,
 }
+
+/// Helper commands, which will not execute probe-run normally.
+const HELPER: [&str; 3] = ["list_chips", "list_probes", "version"];
 
 pub fn handle_arguments() -> anyhow::Result<i32> {
     let opts = Opts::parse();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,7 +91,7 @@ pub struct Opts {
     pub verify: bool,
 
     /// Arguments passed after the ELF file path are discarded
-    #[arg(name = "REST", trailing_var_arg = true)]
+    #[arg(name = "REST", trailing_var_arg = true, hide = true)]
     _rest: Vec<String>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Opts {
     list_probes: bool,
 
     /// The chip to program.
-    #[arg(long, required_unless_present_any(HELPER), env = "PROBE_RUN_CHIP")]
+    #[arg(long, required = true, conflicts_with_all = HELPER, env = "PROBE_RUN_CHIP")]
     chip: Option<String>,
 
     /// Path to chip description file, in YAML format.
@@ -40,7 +40,7 @@ pub struct Opts {
     pub speed: Option<u32>,
 
     /// Path to an ELF firmware file.
-    #[arg(required_unless_present_any(HELPER))]
+    #[arg(required = true, conflicts_with_all = HELPER)]
     elf: Option<PathBuf>,
 
     /// Skip writing the application binary to flash.
@@ -91,7 +91,7 @@ pub struct Opts {
     pub verify: bool,
 
     /// Arguments passed after the ELF file path are discarded
-    #[arg(name = "REST", trailing_var_arg = true, hide = true)]
+    #[arg(allow_hyphen_values = true, hide = true, trailing_var_arg = true)]
     _rest: Vec<String>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,15 +13,15 @@ const EXIT_SUCCESS: i32 = 0;
 
 /// A Cargo runner for microcontrollers.
 #[derive(Parser)]
-#[command(name = "probe-run")]
+#[command()]
 pub struct Opts {
-    /// List supported chips and exit.
-    #[arg(long)]
-    list_chips: bool,
+    /// Disable or enable backtrace (auto in case of panic or stack overflow).
+    #[arg(long, default_value = "auto")]
+    pub backtrace: String,
 
-    /// Lists all the connected probes and exit.
-    #[arg(long)]
-    list_probes: bool,
+    /// Configure the number of lines to print before a backtrace gets cut off.
+    #[arg(long, default_value = "50")]
+    pub backtrace_limit: u32,
 
     /// The chip to program.
     #[arg(long, required = true, conflicts_with_all = HELPER, env = "PROBE_RUN_CHIP")]
@@ -31,17 +31,33 @@ pub struct Opts {
     #[arg(long)]
     pub chip_description_path: Option<PathBuf>,
 
-    /// The probe to use (eg. `VID:PID`, `VID:PID:Serial`, or just `Serial`).
-    #[arg(long, env = "PROBE_RUN_PROBE")]
-    pub probe: Option<String>,
+    /// Connect to device when NRST is pressed.
+    #[arg(long)]
+    pub connect_under_reset: bool,
 
-    /// The probe clock frequency in kHz
-    #[arg(long, env = "PROBE_RUN_SPEED")]
-    pub speed: Option<u32>,
+    /// Disable use of double buffering while downloading flash.
+    #[arg(long)]
+    pub disable_double_buffering: bool,
 
     /// Path to an ELF firmware file.
     #[arg(required = true, conflicts_with_all = HELPER)]
     elf: Option<PathBuf>,
+
+    /// Output logs a structured json.
+    #[arg(long)]
+    pub json: bool,
+
+    /// List supported chips and exit.
+    #[arg(long)]
+    list_chips: bool,
+
+    /// Lists all the connected probes and exit.
+    #[arg(long)]
+    list_probes: bool,
+
+    /// Whether to measure the program's stack consumption.
+    #[arg(long)]
+    pub measure_stack: bool,
 
     /// Skip writing the application binary to flash.
     #[arg(
@@ -51,44 +67,29 @@ pub struct Opts {
     )]
     pub no_flash: bool,
 
-    /// Connect to device when NRST is pressed.
-    #[arg(long)]
-    pub connect_under_reset: bool,
-
-    /// Enable more verbose output.
-    #[arg(short, long, action = ArgAction::Count)]
-    pub verbose: u8,
-
-    /// Prints version information
-    #[arg(short = 'V', long)]
-    version: bool,
-
-    /// Disable or enable backtrace (auto in case of panic or stack overflow).
-    #[arg(long, default_value = "auto")]
-    pub backtrace: String,
-
-    /// Configure the number of lines to print before a backtrace gets cut off
-    #[arg(long, default_value = "50")]
-    pub backtrace_limit: u32,
+    /// The probe to use (eg. `VID:PID`, `VID:PID:Serial`, or just `Serial`).
+    #[arg(long, env = "PROBE_RUN_PROBE")]
+    pub probe: Option<String>,
 
     /// Whether to shorten paths (e.g. to crates.io dependencies) in backtraces and defmt logs
     #[arg(long)]
     pub shorten_paths: bool,
 
-    /// Whether to measure the program's stack consumption.
-    #[arg(long)]
-    pub measure_stack: bool,
+    /// The probe clock frequency in kHz
+    #[arg(long, env = "PROBE_RUN_SPEED")]
+    pub speed: Option<u32>,
 
-    #[arg(long)]
-    pub json: bool,
-
-    /// Disable use of double buffering while downloading flash
-    #[arg(long)]
-    pub disable_double_buffering: bool,
+    /// Enable more verbose output.
+    #[arg(short, long, action = ArgAction::Count)]
+    pub verbose: u8,
 
     /// Verifies the written program.
     #[arg(long)]
     pub verify: bool,
+
+    /// Prints version information
+    #[arg(short = 'V', long)]
+    version: bool,
 
     /// Arguments passed after the ELF file path are discarded
     #[arg(allow_hyphen_values = true, hide = true, trailing_var_arg = true)]


### PR DESCRIPTION
This PR updates our cli parser `clap` from `2.34` to `4.0`.

The end-user experience should stay similar, but has a fresh UI, many internal improvements, and better help messages when a user gets the arguments wrong.

On the left you can see the new UI, and on the right the old.
![image](https://user-images.githubusercontent.com/37087391/194344377-e49958f1-412e-45f4-9199-8108d8356368.png)
