### PR TITLE
Fix unwinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 
 - [#384] Satisfy clippy
+- [#383] Fix unwinding
 - [#381] Add feature `ftdi` to enable `ftdi` debuggers
 - [#380] Add `--erase-all` flag
 - [#379] Update to `probe-rs v0.17`
 - [#378] Update to `probe-rs v0.16`
 
 [#384]: https://github.com/knurling-rs/probe-run/pull/384
+[#383]: https://github.com/knurling-rs/probe-run/pull/383
 [#381]: https://github.com/knurling-rs/probe-run/pull/381
 [#380]: https://github.com/knurling-rs/probe-run/pull/380
 [#379]: https://github.com/knurling-rs/probe-run/pull/379

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -42,8 +42,9 @@ pub fn print(
     elf: &Elf,
     active_ram_region: &Option<RamRegion>,
     settings: &mut Settings<'_>,
+    stack_start: u32,
 ) -> anyhow::Result<Outcome> {
-    let unwind = unwind::target(core, elf, active_ram_region);
+    let unwind = unwind::target(core, elf, active_ram_region, stack_start);
 
     let frames = symbolicate::frames(&unwind.raw_frames, settings.current_dir, elf);
 

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{ops::Range, path::Path};
 
 use probe_rs::{config::RamRegion, Core};
 use signal_hook::consts::signal;
@@ -43,8 +43,9 @@ pub fn print(
     active_ram_region: &Option<RamRegion>,
     settings: &mut Settings<'_>,
     stack_start: u32,
+    reset_range: Range<u32>,
 ) -> anyhow::Result<Outcome> {
-    let unwind = unwind::target(core, elf, active_ram_region, stack_start);
+    let unwind = unwind::target(core, elf, active_ram_region, stack_start, reset_range);
 
     let frames = symbolicate::frames(&unwind.raw_frames, settings.current_dir, elf);
 

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -95,6 +95,10 @@ pub fn target(
 
         log::debug!("LR={lr:#010X} PC={pc:#010X}");
 
+        // Link Register contains an EXC_RETURN value. This deliberately also includes
+        // invalid combinations of final bits 0-4 to prevent futile backtrace re-generation attempts
+        let exception_entry = lr >= cortexm::EXC_RETURN_MARKER;
+
         let program_counter_changed = !cortexm::subroutine_eq(lr, pc);
 
         // If the frame didn't move, and the program counter didn't change, bail out
@@ -104,10 +108,6 @@ pub fn target(
             output.corrupted = !reset_range.contains(&pc);
             break;
         }
-
-        // Link Register contains an EXC_RETURN value. This deliberately also includes
-        // invalid combinations of final bits 0-4 to prevent futile backtrace re-generation attempts
-        let exception_entry = lr >= cortexm::EXC_RETURN_MARKER;
 
         if exception_entry {
             output.raw_frames.push(RawFrame::Exception);

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -147,10 +147,12 @@ pub fn target(
         }
 
         // if the SP is above the start of the stack, the stack is corrupt
-        let advanced_sp = registers.get(registers::SP).unwrap();
-        if advanced_sp > stack_start {
-            output.corrupted = true;
-            break;
+        match registers.get(registers::SP) {
+            Ok(advanced_sp) if advanced_sp > stack_start => {
+                output.corrupted = true;
+                break;
+            }
+            _ => {}
         }
     }
 

--- a/src/backtrace/unwind.rs
+++ b/src/backtrace/unwind.rs
@@ -87,10 +87,6 @@ pub fn target(core: &mut Core, elf: &Elf, active_ram_region: &Option<RamRegion>)
 
         log::debug!("LR={lr:#010X} PC={pc:#010X}");
 
-        if lr == registers::LR_END {
-            break;
-        }
-
         // Link Register contains an EXC_RETURN value. This deliberately also includes
         // invalid combinations of final bits 0-4 to prevent futile backtrace re-generation attempts
         let exception_entry = lr >= cortexm::EXC_RETURN_MARKER;

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashSet,
-    convert::TryInto,
-    env,
-    ops::{Deref, Range},
-    path::Path,
-};
+use std::{collections::HashSet, convert::TryInto, env, ops::Deref, path::Path};
 
 use anyhow::{anyhow, bail};
 use defmt_decoder::{Locations, Table};
@@ -62,10 +56,6 @@ impl<'file> Elf<'file> {
 
     pub fn rtt_buffer_address(&self) -> Option<u32> {
         self.symbols.rtt_buffer_address
-    }
-
-    pub fn reset_fn_range(&self) -> Range<u32> {
-        self.symbols.reset_fn_range.clone()
     }
 }
 
@@ -178,14 +168,12 @@ struct Symbols {
     rtt_buffer_address: Option<u32>,
     program_uses_heap: bool,
     main_fn_address: u32,
-    reset_fn_range: Range<u32>,
 }
 
 fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
     let mut rtt_buffer_address = None;
     let mut program_uses_heap = false;
     let mut main_fn_address = None;
-    let mut reset_fn_range = None;
 
     for symbol in elf.symbols() {
         let name = match symbol.name() {
@@ -202,21 +190,15 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
                 log::debug!("symbol `{}` indicates heap is in use", name);
                 program_uses_heap = true;
             }
-            "Reset" => {
-                let size: u32 = symbol.size().try_into().expect("expected 32-bit ELF");
-                reset_fn_range = Some(address..(address + size));
-            }
             _ => {}
         }
     }
 
     let main_fn_address = main_fn_address.ok_or(anyhow!("`main` symbol not found"))?;
-    let reset_fn_range = reset_fn_range.ok_or(anyhow!("`reset` symbol not found"))?;
 
     Ok(Symbols {
         rtt_buffer_address,
         program_uses_heap,
         main_fn_address,
-        reset_fn_range,
     })
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -182,7 +182,6 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
         };
 
         let address = symbol.address().try_into().expect("expected 32-bit ELF");
-
         match name {
             "main" => main_fn_address = Some(cortexm::clear_thumb_bit(address)),
             "_SEGGER_RTT" => rtt_buffer_address = Some(address),
@@ -194,11 +193,12 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
         }
     }
 
-    let main_fn_address = main_fn_address.ok_or(anyhow!("`main` symbol not found"))?;
+    let main_function_address =
+        main_fn_address.ok_or_else(|| anyhow!("`main` symbol not found"))?;
 
     Ok(Symbols {
         rtt_buffer_address,
         program_uses_heap,
-        main_fn_address,
+        main_fn_address: main_function_address,
     })
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashSet,
-    convert::TryInto,
-    env,
-    ops::{Deref, Range},
-    path::Path,
-};
+use std::{collections::HashSet, convert::TryInto, env, ops::Deref, path::Path};
 
 use anyhow::{anyhow, bail};
 use defmt_decoder::{Locations, Table};
@@ -15,7 +9,7 @@ use object::{
 use crate::cortexm;
 
 pub struct Elf<'file> {
-    elf: ObjectFile<'file>,
+    pub elf: ObjectFile<'file>,
     symbols: Symbols,
 
     pub debug_frame: DebugFrame<'file>,
@@ -62,10 +56,6 @@ impl<'file> Elf<'file> {
 
     pub fn rtt_buffer_address(&self) -> Option<u32> {
         self.symbols.rtt_buffer_address
-    }
-
-    pub fn reset_fn_range(&self) -> Range<u32> {
-        self.symbols.reset_fn_range.clone()
     }
 }
 
@@ -178,14 +168,12 @@ struct Symbols {
     rtt_buffer_address: Option<u32>,
     program_uses_heap: bool,
     main_fn_address: u32,
-    reset_fn_range: Range<u32>,
 }
 
 fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
     let mut rtt_buffer_address = None;
     let mut program_uses_heap = false;
     let mut main_fn_address = None;
-    let mut reset_fn_range = None;
 
     for symbol in elf.symbols() {
         let name = match symbol.name() {
@@ -202,21 +190,15 @@ fn extract_symbols(elf: &ObjectFile) -> anyhow::Result<Symbols> {
                 log::debug!("symbol `{}` indicates heap is in use", name);
                 program_uses_heap = true;
             }
-            "Reset" => {
-                let size: u32 = symbol.size().try_into().expect("expected 32-bit ELF");
-                reset_fn_range = Some(address..(address + size));
-            }
             _ => {}
         }
     }
 
     let main_fn_address = main_fn_address.ok_or(anyhow!("`main` symbol not found"))?;
-    let reset_fn_range = reset_fn_range.ok_or(anyhow!("`reset` symbol not found"))?;
 
     Ok(Symbols {
         rtt_buffer_address,
         program_uses_heap,
         main_fn_address,
-        reset_fn_range,
     })
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -7,8 +7,6 @@ pub const LR: RegisterId = RegisterId(14);
 pub const PC: RegisterId = RegisterId(15);
 pub const SP: RegisterId = RegisterId(13);
 
-pub const LR_END: u32 = 0xFFFF_FFFF;
-
 /// Cache and track the state of CPU registers while the stack is being unwound.
 pub struct Registers<'c, 'probe> {
     cache: BTreeMap<u16, u32>,


### PR DESCRIPTION
This PR "fixes" unwinding, by not relying on the sentinel stack frame anymore, but instead checking if unwinding ends in the `Reset` function. If unwinding ends in the `Reset` function, it is considered NOT corrupted; if it ends somewhere else, it is considered corrupted.

Fixes #382 

Todo:
- ❌ ~~Is the `Reset` symbol always present?~~ -> No, "an unmangled symbol named `Reset` is even less common than main"
- ❌  ~~Does any thumb bit need to be cleared?~~ -> no
- ❌  ~~Test it with an corrupted stack~~ -> not trivially possible from Rust