### PR TITLE
Clean `fn run_target_program` up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#xxx] Clean `fn run_target_program` up
+
+[#xxx]: https://github.com/knurling-rs/probe-run/pull/xxx
+
 ## [v0.3.6] - 2023-01-23
 
 - [#xxx] Release `probe-run v0.3.7`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-- [#xxx] Clean `fn run_target_program` up
+- [#389] Clean `fn run_target_program` up
 
-[#xxx]: https://github.com/knurling-rs/probe-run/pull/xxx
+[#389]: https://github.com/knurling-rs/probe-run/pull/389
 
 ## [v0.3.6] - 2023-01-23
 

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -49,14 +49,14 @@ pub struct Canary {
 
 impl Canary {
     /// Decide if and where to place the stack canary.
+    ///
+    /// Assumes that the target was reset-halted.
     pub fn install(
         core: &mut Core,
         target_info: &TargetInfo,
         elf: &Elf,
         measure_stack: bool,
     ) -> Result<Option<Self>, anyhow::Error> {
-        core.reset_and_halt(TIMEOUT)?;
-
         let stack_info = match &target_info.stack_info {
             Some(stack_info) => stack_info,
             None => {

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use probe_rs::{Core, MemoryInterface, RegisterId, Session};
+use probe_rs::{Core, MemoryInterface, RegisterId};
 
 use crate::{registers::PC, Elf, TargetInfo, TIMEOUT};
 
@@ -50,12 +50,11 @@ pub struct Canary {
 impl Canary {
     /// Decide if and where to place the stack canary.
     pub fn install(
-        sess: &mut Session,
+        core: &mut Core,
         target_info: &TargetInfo,
         elf: &Elf,
         measure_stack: bool,
     ) -> Result<Option<Self>, anyhow::Error> {
-        let mut core = sess.core(0)?;
         core.reset_and_halt(TIMEOUT)?;
 
         let stack_info = match &target_info.stack_info {
@@ -93,7 +92,7 @@ impl Canary {
             log::info!("painting {size_kb:.2} KiB of RAM for stack usage estimation");
         }
         let start = Instant::now();
-        paint_subroutine::execute(&mut core, stack_start, size as u32)?;
+        paint_subroutine::execute(core, stack_start, size as u32)?;
         let seconds = start.elapsed().as_secs_f64();
         log::trace!(
             "setting up canary took {seconds:.3}s ({:.2} KiB/s)",
@@ -110,7 +109,7 @@ impl Canary {
     }
 
     /// Detect if the stack canary was touched.
-    pub fn touched(self, core: &mut probe_rs::Core, elf: &Elf) -> anyhow::Result<bool> {
+    pub fn touched(self, core: &mut Core, elf: &Elf) -> anyhow::Result<bool> {
         let size_kb = self.size as f64 / 1024.0;
         if self.measure_stack {
             log::info!("reading {size_kb:.2} KiB of RAM for stack usage estimation");

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -27,10 +27,7 @@ pub struct StackInfo {
 }
 
 impl TargetInfo {
-    pub fn new(chip: &str, elf: &Elf) -> anyhow::Result<Self> {
-        let probe_target = probe_rs::config::get_target_by_name(chip)?;
-        check_processor_target_compatability(&probe_target.cores, elf.elf_path);
-
+    pub fn new(elf: &Elf, probe_target: probe_rs::Target) -> anyhow::Result<Self> {
         let active_ram_region =
             extract_active_ram_region(&probe_target, elf.vector_table.initial_stack_pointer);
         let stack_info = active_ram_region
@@ -46,7 +43,7 @@ impl TargetInfo {
 }
 
 /// Check if the compilation target and processor fit and emit a warning if not.
-fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
+pub fn check_processor_target_compatability(core: &Core, elf_path: &Path) {
     let target = elf_path.iter().find_map(|a| {
         let b = a.to_string_lossy();
         match b.starts_with("thumbv") {
@@ -61,7 +58,7 @@ fn check_processor_target_compatability(cores: &[Core], elf_path: &Path) {
     };
 
     // NOTE(indexing): There *must* always be at least one core.
-    let core_type = cores[0].core_type;
+    let core_type = core.core_type;
     let matches = match core_type {
         CoreType::Armv6m => target == "thumbv6m-none-eabi",
         CoreType::Armv7m => target == "thumbv7m-none-eabi",

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -14,9 +14,10 @@ use probe_rs::{
 use crate::elf::Elf;
 
 pub struct TargetInfo {
-    pub probe_target: probe_rs::Target,
     /// RAM region that contains the call stack
     pub active_ram_region: Option<RamRegion>,
+    pub memory_map: Vec<MemoryRegion>,
+    pub probe_target: probe_rs::Target,
     pub stack_info: Option<StackInfo>,
 }
 
@@ -27,7 +28,11 @@ pub struct StackInfo {
 }
 
 impl TargetInfo {
-    pub fn new(elf: &Elf, probe_target: probe_rs::Target) -> anyhow::Result<Self> {
+    pub fn new(
+        elf: &Elf,
+        memory_map: Vec<MemoryRegion>,
+        probe_target: probe_rs::Target,
+    ) -> anyhow::Result<Self> {
         let active_ram_region =
             extract_active_ram_region(&probe_target, elf.vector_table.initial_stack_pointer);
         let stack_info = active_ram_region
@@ -35,8 +40,9 @@ impl TargetInfo {
             .and_then(|ram_region| extract_stack_info(elf, &ram_region.range));
 
         Ok(Self {
-            probe_target,
             active_ram_region,
+            memory_map,
+            probe_target,
             stack_info,
         })
     }

--- a/src/target_info.rs
+++ b/src/target_info.rs
@@ -19,6 +19,7 @@ pub struct TargetInfo {
     pub memory_map: Vec<MemoryRegion>,
     pub probe_target: probe_rs::Target,
     pub stack_info: Option<StackInfo>,
+    pub stack_start: u32,
 }
 
 pub struct StackInfo {
@@ -32,6 +33,7 @@ impl TargetInfo {
         elf: &Elf,
         memory_map: Vec<MemoryRegion>,
         probe_target: probe_rs::Target,
+        stack_start: u32,
     ) -> anyhow::Result<Self> {
         let active_ram_region =
             extract_active_ram_region(&probe_target, elf.vector_table.initial_stack_pointer);
@@ -44,6 +46,7 @@ impl TargetInfo {
             memory_map,
             probe_target,
             stack_info,
+            stack_start,
         })
     }
 }


### PR DESCRIPTION
This PR aims to simplify the (humongous) inofficial main function `fn run_target_program`. It reduces it from 119 to 48 lines of code.