### PR TITLE
chore: Bump defmt-decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#395] Bump `defmt-decoder` to `0.3.6` due to yanked version `0.3.5`
 - [#389] Clean `fn run_target_program` up
 
+[#395]: https://github.com/knurling-rs/probe-run/pull/395
 [#389]: https://github.com/knurling-rs/probe-run/pull/389
 
 ## [v0.3.6] - 2023-01-23
@@ -56,6 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [#345]: https://github.com/knurling-rs/probe-run/pull/345
 [#344]: https://github.com/knurling-rs/probe-run/pull/344
 [#343]: https://github.com/knurling-rs/probe-run/pull/343
+[#353]: https://github.com/knurling-rs/probe-run/pull/353
 
 ## [v0.3.4] - 2022-08-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ addr2line = { version = "0.19", default-features = false, features = [
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
 colored = "2"
-defmt-decoder = { version = "=0.3.5", features = ["unstable"] }
+defmt-decoder = { version = "=0.3.6", features = ["unstable"] }
 gimli = { version = "0.27", default-features = false }
 git-version = "0.3"
 log = "0.4"


### PR DESCRIPTION
Reason: 0.3.5 has been yanked and it's not currently possible to install the latest version of `probe-run`

Fixes #393 