### PR TITLE
Release version 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [v0.3.8] - 2023-04-12
+
 - [#395] Bump `defmt-decoder` to `0.3.6` due to yanked version `0.3.5`
 - [#389] Clean `fn run_target_program` up
 
 [#395]: https://github.com/knurling-rs/probe-run/pull/395
 [#389]: https://github.com/knurling-rs/probe-run/pull/389
 
-## [v0.3.6] - 2023-01-23
+## [v0.3.7] - 2023-03-29
 
 - [#xxx] Release `probe-run v0.3.7`
 - [#385] Update snapshot tests and test stack canary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-decoder"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fff6df2c2a0ddec2914cdf1c91b35f4f9ef0c5f06798ec1f62ebb12f4b9836"
+checksum = "274366b014d7d1134d9a43a50e591832f8af1ca7fcba1d620eb8e2de093d02de"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "probe-run"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "addr2line",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "probe-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/probe-run"
-version = "0.3.7"
+version = "0.3.8"
 
 [dependencies]
 addr2line = { version = "0.19", default-features = false, features = [


### PR DESCRIPTION
This PR fixes the dependency issues reported in #393, 

* bump version of probe-run to `0.3.8`
* add release entry in change log
* fix date and release version in change log