### PR TITLE
Switch from bors to merge queue

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,2 +1,0 @@
-delete_merged_branches = true
-status = ["ci"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,8 @@ on:
     branches: [ main, staging, trying ]
   pull_request:
     branches: [ main ]
+  merge_group:
 
-# NOTE if you add, remove or rename a job you'll need to update the list of
-# jobs in the `ci` step (at the bottom of this file)
 jobs:
   test:
     strategy:
@@ -40,15 +39,3 @@ jobs:
 
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
-
-  # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
-  # bors.tech integration
-  ci:
-    if: ${{ success() }}
-    needs:
-      - test
-      - static
-    runs-on: ubuntu-latest
-    steps:
-      - name: CI succeeded
-        run: exit 0


### PR DESCRIPTION
The publicly hosted instance of bors-ng is deprecated. Therefore we switch to GitHub merge queue.

Two things are happening:
- This PR edits config files to switch from bors to the new github merge queue. 
- Additionally the repository settings and in particular the branch protection rules are edited as described in [the docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

I am a bit unsure how to test this without creating a huge amount of pull requests, but I hope the changed settings already take effect for this PR.