### PR TITLE
Simplify canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+- [#410] Simplify canary
 - [#405] Also enable merge queue for changelog enforcer
 - [#404] Switch from bors to merge queue
 - [#402] Do not panic if locations do not contain the frame
 
+[#410]: https://github.com/knurling-rs/probe-run/pull/410
 [#405]: https://github.com/knurling-rs/probe-run/pull/405
 [#404]: https://github.com/knurling-rs/probe-run/pull/404
 [#402]: https://github.com/knurling-rs/probe-run/pull/402

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -404,7 +404,7 @@ mod measure_subroutine {
 ///
 /// # How?
 ///
-/// We place the parameters in the registers (see table below), place the subroutien
+/// We place the parameters in the registers (see table below), place the subroutine
 /// in memory, set the program counter to the beginning of the subroutine, execute
 /// the subroutine and reset the program counter afterwards.
 ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,7 +124,7 @@ pub fn handle_arguments() -> anyhow::Result<i32> {
     });
 
     if opts.measure_stack {
-        log::warn!("use of deprecated option `--measure-stack`: Has no effect anymore and will vanish on next minor release")
+        log::warn!("use of deprecated option `--measure-stack`: Has no effect and will vanish on next breaking release")
     }
 
     if opts.version {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,10 @@ pub fn handle_arguments() -> anyhow::Result<i32> {
         }
     });
 
+    if opts.measure_stack {
+        log::warn!("use of deprecated option `--measure-stack`: Has no effect anymore and will vanish on next minor release")
+    }
+
     if opts.version {
         print_version();
         Ok(EXIT_SUCCESS)

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     let target_info = TargetInfo::new(elf, memory_map, probe_target, stack_start)?;
 
     // install stack canary
-    let canary = Canary::install(core, &target_info, elf)?;
+    let canary = Canary::install(core, elf, &target_info)?;
     if canary.is_none() {
         log::info!("stack measurement was not set up");
     }
@@ -84,7 +84,7 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
 
     // analyze stack canary
     let stack_overflow = canary
-        .map(|canary| canary.touched(core, elf))
+        .map(|canary| canary.measure(core, elf))
         .transpose()?
         .unwrap_or(false);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,19 +78,19 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
 
     // run program and print logs until there is an exception
     start_program(core, elf)?;
-    let current_dir = &env::current_dir()?;
-    let halted_due_to_signal = print_logs(core, current_dir, elf, &target_info.memory_map, opts)?; // blocks until exception
+    let current_dir = env::current_dir()?;
+    let halted_due_to_signal = print_logs(core, &current_dir, elf, &target_info.memory_map, opts)?; // blocks until exception
     print_separator()?;
 
     // analyze stack canary
-    let canary_touched = canary
+    let stack_overflow = canary
         .map(|canary| canary.touched(core, elf))
         .transpose()?
         .unwrap_or(false);
 
     // print the backtrace
     let mut backtrace_settings =
-        backtrace::Settings::new(canary_touched, current_dir, halted_due_to_signal, opts);
+        backtrace::Settings::new(current_dir, halted_due_to_signal, opts, stack_overflow);
     let outcome = backtrace::print(core, elf, &target_info, &mut backtrace_settings)?;
 
     // reset the target

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,9 +71,9 @@ fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> any
     let target_info = TargetInfo::new(elf, memory_map, probe_target, stack_start)?;
 
     // install stack canary
-    let canary = Canary::install(core, &target_info, elf, opts.measure_stack)?;
-    if opts.measure_stack && canary.is_none() {
-        bail!("failed to set up stack measurement");
+    let canary = Canary::install(core, &target_info, elf)?;
+    if canary.is_none() {
+        log::info!("stack measurement was not set up");
     }
 
     // run program and print logs until there is an exception

--- a/tests/snapshots/snapshot__case_1_successful_run_has_no_backtrace.snap
+++ b/tests/snapshots/snapshot__case_1_successful_run_has_no_backtrace.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot.rs
-assertion_line: 113
+assertion_line: 114
 expression: run_result.output
 
 ---
@@ -9,5 +9,6 @@ expression: run_result.output
 ────────────────────────────────────────────────────────────────────────────────
 Hello, world!
 ────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  program has used at least 0.16/254.93 KiB (0.1%) of stack space
 (HOST) INFO  device halted without error
 

--- a/tests/snapshots/snapshot__case_2_raw_encoding.snap
+++ b/tests/snapshots/snapshot__case_2_raw_encoding.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot.rs
-assertion_line: 113
+assertion_line: 114
 expression: run_result.output
 
 ---
@@ -9,5 +9,6 @@ expression: run_result.output
 ────────────────────────────────────────────────────────────────────────────────
 Hello, world!
 ────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  program has used at least 0.12/254.93 KiB (0.0%) of stack space
 (HOST) INFO  device halted without error
 

--- a/tests/snapshots/snapshot__case_3_successful_run_can_enforce_backtrace.snap
+++ b/tests/snapshots/snapshot__case_3_successful_run_can_enforce_backtrace.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot.rs
-assertion_line: 113
+assertion_line: 114
 expression: run_result.output
 
 ---
@@ -9,6 +9,7 @@ expression: run_result.output
 ────────────────────────────────────────────────────────────────────────────────
 Hello, world!
 ────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  program has used at least 0.16/254.93 KiB (0.1%) of stack space
 stack backtrace:
    0: lib::inline::__bkpt
         at ./asm/inline.rs:14:5

--- a/tests/snapshots/snapshot__case_5_panic_is_reported_as_such.snap
+++ b/tests/snapshots/snapshot__case_5_panic_is_reported_as_such.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot.rs
-assertion_line: 113
+assertion_line: 114
 expression: run_result.output
 
 ---
@@ -9,6 +9,7 @@ expression: run_result.output
 ────────────────────────────────────────────────────────────────────────────────
 ERROR panicked at 'explicit panic'
 ────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  program has used at least 0.16/254.93 KiB (0.1%) of stack space
 stack backtrace:
    0: HardFaultTrampoline
       <exception entry>

--- a/tests/snapshots/snapshot__case_6_panic_verbose.snap
+++ b/tests/snapshots/snapshot__case_6_panic_verbose.snap
@@ -1,33 +1,34 @@
 ---
 source: tests/snapshot.rs
-assertion_line: 113
+assertion_line: 114
 expression: run_result.output
 
 ---
+(HOST) DEBUG found 1 probes
+(HOST) DEBUG opened probe
+(HOST) DEBUG started session
+(HOST) INFO  flashing program (2 pages / 8.00 KiB)
+(HOST) DEBUG Erased sector of size 4096 bytes in 122 ms
+(HOST) DEBUG Erased sector of size 4096 bytes in 101 ms
+(HOST) DEBUG Programmed page of size 4096 bytes in 66 ms
+(HOST) DEBUG Programmed page of size 4096 bytes in 67 ms
+(HOST) INFO  success!
 (HOST) DEBUG vector table: VectorTable { initial_stack_pointer: 2003fbc0, hard_fault: 17d3 }
 (HOST) DEBUG RAM region: 0x20000000-0x2003FFFF
 (HOST) DEBUG section `.data` is in RAM at 0x2003FBC0..=0x2003FBF7
 (HOST) DEBUG section `.bss` is in RAM at 0x2003FBF8..=0x2003FBFF
 (HOST) DEBUG section `.uninit` is in RAM at 0x2003FC00..=0x2003FFFF
 (HOST) DEBUG valid SP range: 0x20000000..=0x2003FBBC
-(HOST) DEBUG found 1 probes
-(HOST) DEBUG opened probe
-(HOST) DEBUG started session
-(HOST) INFO  flashing program (2 pages / 8.00 KiB)
-(HOST) DEBUG Erased sector of size 4096 bytes in 121 ms
-(HOST) DEBUG Erased sector of size 4096 bytes in 99 ms
-(HOST) DEBUG Programmed page of size 4096 bytes in 62 ms
-(HOST) DEBUG Programmed page of size 4096 bytes in 62 ms
-(HOST) INFO  success!
-(HOST) DEBUG 261052 bytes of stack available (0x20000000 ..= 0x2003FBBC), using 1024 byte canary
-(HOST) TRACE setting up canary took 0.020s (51.19 KiB/s)
+(HOST) DEBUG 261052 bytes of stack available (0x20000000 ..= 0x2003FBBC)
+(HOST) DEBUG painting 254.93 KiB of RAM took 0.031s (8287.09 KiB/s)
 (HOST) DEBUG starting device
 (HOST) DEBUG Successfully attached RTT
 ────────────────────────────────────────────────────────────────────────────────
 ERROR panicked at 'explicit panic'
 ────────────────────────────────────────────────────────────────────────────────
-(HOST) TRACE reading canary took 0.024s (41.48 KiB/s)
-(HOST) DEBUG stack canary intact
+(HOST) DEBUG reading 254.93 KiB of RAM took 0.048s (5308.39 KiB/s)
+(HOST) DEBUG stack was touched at 0x2003FB20
+(HOST) INFO  program has used at least 0.16/254.93 KiB (0.1%) of stack space
 (HOST) TRACE 0x000017d2: found FDE for 0x000017d2 .. 0x000017ea at offset 5672
 (HOST) TRACE uwt row for pc 0x000017d2: UnwindTableRow { start_address: 6098, end_address: 6122, saved_args_size: 0, cfa: RegisterAndOffset { register: Register(13), offset: 0 }, registers: RegisterRuleMap { rules: [] } }
 (HOST) DEBUG LR=0xFFFFFFF9 PC=0x000017D2

--- a/tests/snapshots/snapshot__case_7_unsuccessful_run_can_suppress_backtrace.snap
+++ b/tests/snapshots/snapshot__case_7_unsuccessful_run_can_suppress_backtrace.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshot.rs
+assertion_line: 114
 expression: run_result.output
 
 ---
@@ -8,5 +9,6 @@ expression: run_result.output
 ────────────────────────────────────────────────────────────────────────────────
 ERROR panicked at 'explicit panic'
 ────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  program has used at least 0.16/254.93 KiB (0.1%) of stack space
 (HOST) ERROR the program panicked
 

--- a/tests/snapshots/snapshot__ctrl_c_by_user_is_reported_as_such.snap
+++ b/tests/snapshots/snapshot__ctrl_c_by_user_is_reported_as_such.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot.rs
-assertion_line: 123
+assertion_line: 124
 expression: run_result.output
 
 ---
@@ -8,6 +8,7 @@ expression: run_result.output
 (HOST) INFO  success!
 ────────────────────────────────────────────────────────────────────────────────
 ────────────────────────────────────────────────────────────────────────────────
+(HOST) INFO  program has used at least 0.13/254.93 KiB (0.1%) of stack space
 stack backtrace:
    0: silent_loop::__cortex_m_rt_main
         at /tmp/app/src/bin/silent-loop.rs:9:5


### PR DESCRIPTION
This PR simplifies our canary system. This is possible now, because our stack-painting and stack-measuring got blazingly fast due to #302 #327 #331.

Adds work around for #323.

# What

Before this PR there were two modes. By default `probe-run` would only paint 10% of stack and use that to detect potential stack-overflows. If a user would pass `--measure-stack`, `probe-run` would paint the whole stack (which was slow) and report the percentage of stack used, but don't notify about potential stack-overflows.

After this PR there is only a single mode. `probe-run` always paints the whole stack (which is fast), always reports the percentage of stack used and always reports potential stack-overflows.

The `--measure-stack` option is not completely removed to avoid a breaking change. But it does not do anything anymore except emitting a deprecation warning.

Some other drive-by changes:
- assert subroutine requirements more early, therefore work around #323
- refactor `Settings` to not need a lifetime

# Testing

The unit testing[^1] and on-device tests[^2] succeed

# Note to reviewer

While the whole PR got kinda big, the individual commits should be rather self-contained and therefore easier to review.


[^1]: `cargo test`
[^2]: `cargo test -- --ignored`