### PR TITLE
Hide location printing for defmt frames behind another verbosity level

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,17 +107,19 @@ pub fn handle_arguments() -> anyhow::Result<i32> {
     let opts = Opts::parse();
     let verbose = opts.verbose;
 
-    defmt_decoder::log::init_logger(verbose >= 1, opts.json, move |metadata| {
+    defmt_decoder::log::init_logger(verbose >= 1, verbose >= 2, opts.json, move |metadata| {
         if defmt_decoder::log::is_defmt_frame(metadata) {
             true // We want to display *all* defmt frames.
         } else {
             // Log depending on how often the `--verbose` (`-v`) cli-param is supplied:
-            //   * 0: log everything from probe-run, with level "info" or higher
-            //   * 1: log everything from probe-run
-            //   * 2 or more: log everything
+            //   * 0 to 1: log everything from probe-run, with level "info" or higher
+            //   * 2: log everything from probe-run
+            //   * 3 or more: log everything
             match verbose {
-                0 => metadata.target().starts_with("probe_run") && metadata.level() <= Level::Info,
-                1 => metadata.target().starts_with("probe_run"),
+                0..=1 => {
+                    metadata.target().starts_with("probe_run") && metadata.level() <= Level::Info
+                }
+                2 => metadata.target().starts_with("probe_run"),
                 _ => true,
             }
         }


### PR DESCRIPTION
Depends on https://github.com/knurling-rs/defmt/pull/762.

Addresses #412 and #407.

This PR changes the default (without flags) output to omit location for all defmt frames. Personally I think this is more convenient when you're _running_ your firmware and not _debugging_ it since the log is easier to read and you don't care about locations at this point anyway, but this comes down to personal preference. A less invasive option is to add a `--terse` option and to set the verbosity level to `1 + opts.verbose - opts.terse`; then the default output will remain the same.

A very minimal solution that addresses #412 but not #407 is to skip printing of location only for `println!` frames if `always_include_location` is not set, and leave everything else the same.

I'm happy to implement any of the options above, or really any other option that's suggested.