### PR TITLE
Prepare `v0.3.11` (the final release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [v0.3.11] - 2024-01-29
+
 - [#423] Add better defaults for log format when timestamp is available
 
 [#423]: https://github.com/knurling-rs/probe-run/pull/423
@@ -507,7 +509,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/probe-run/compare/v0.3.10...main
+[Unreleased]: https://github.com/knurling-rs/probe-run/compare/v0.3.11...main
+[v0.3.10]: https://github.com/knurling-rs/probe-run/compare/v0.3.10...v0.3.11
 [v0.3.10]: https://github.com/knurling-rs/probe-run/compare/v0.3.9...v0.3.10
 [v0.3.9]: https://github.com/knurling-rs/probe-run/compare/v0.3.8...v0.3.9
 [v0.3.8]: https://github.com/knurling-rs/probe-run/compare/v0.3.7...v0.3.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "probe-run"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "addr2line",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "probe-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/probe-run"
-version = "0.3.10"
+version = "0.3.11"
 
 [dependencies]
 addr2line = { version = "0.20", default-features = false, features = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,22 @@ const DEFAULT_HOST_LOG_FORMAT: &str = "(HOST) {L} {s}";
 const DEFAULT_VERBOSE_HOST_LOG_FORMAT: &str = "(HOST) {L} {s}\n└─ {m} @ {F}:{l}";
 
 fn main() -> anyhow::Result<()> {
+    deprecated();
+
     configure_terminal_colorization();
 
     #[allow(clippy::redundant_closure)]
     cli::handle_arguments().map(|code| process::exit(code))
+}
+
+#[deprecated = "⚠️  As of 11.10.2023 `probe-run` is in maintainance mode. We \
+recommend everyone to switch to `probe-rs`. Read following article on the why \
+and on how to migrate: https://ferrous-systems.com/blog/probe-run-deprecation/"]
+fn deprecated() {
+    eprintln!("⚠️  As of 11.10.2023 `probe-run` is in maintainance mode. We \
+    recommend everyone to switch to `probe-rs`. Read following article on the \
+    why and on how to migrate: \
+    https://ferrous-systems.com/blog/probe-run-deprecation/\n");
 }
 
 fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> anyhow::Result<i32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,10 +62,11 @@ fn main() -> anyhow::Result<()> {
 recommend everyone to switch to `probe-rs`. Read following article on the why \
 and on how to migrate: https://ferrous-systems.com/blog/probe-run-deprecation/"]
 fn deprecated() {
-    eprintln!("⚠️  As of 11.10.2023 `probe-run` is in maintainance mode. We \
-    recommend everyone to switch to `probe-rs`. Read following article on the \
-    why and on how to migrate: \
-    https://ferrous-systems.com/blog/probe-run-deprecation/\n");
+    eprintln!(
+        "⚠️  As of 11.10.2023 `probe-run` is in maintainance mode. We recommend \
+        everyone to switch to `probe-rs`. Read following article on the why and \
+        on how to migrate: https://ferrous-systems.com/blog/probe-run-deprecation/\n"
+    );
 }
 
 fn run_target_program(elf_path: &Path, chip_name: &str, opts: &cli::Opts) -> anyhow::Result<i32> {


### PR DESCRIPTION
Using the `deprecated` attribute is a bit of a hack, but it was the easiest way to issue a warning on build time I could find.

Fixes #430 

---

TODO
- [x] publish release (`cargo publish`)
- [x] add `v0.3.11` git tag
- [ ] archive repository